### PR TITLE
Thread restoration and syscall restarting

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -23,7 +23,6 @@ ULP_PACKER = $(top_builddir)/tools/ulp_packer
 ULP_REVERSE = $(top_builddir)/tools/ulp_reverse
 
 # Build and link requirements for live-patchable (target) libraries.
-ULP_NOP_LENGTH = @ULP_NOP_LENGTH@
 TARGET_CFLAGS = \
   -fPIC \
   -fpatchable-function-entry=$(ULP_NOPS_LEN),$(PRE_NOPS_LEN) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -189,7 +189,8 @@ check_PROGRAMS = \
   redzone \
   pagecross \
   loop \
-  terminal
+  terminal \
+  syscall_restart
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -202,6 +203,10 @@ numserv_bsymbolic_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 parameters_SOURCES = parameters.c
 parameters_LDADD = libparameters.la
 parameters_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+syscall_restart_SOURCES = syscall_restart.c
+syscall_restart_LDADD = libparameters.la
+syscall_restart_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 recursion_SOURCES = recursion.c
 recursion_LDADD = librecursion.la
@@ -253,7 +258,8 @@ TESTS = \
   revert.py \
   pagecross.py \
   terminal.py \
-  thread_restore.py
+  thread_restore.py \
+  syscall_restart.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -255,8 +255,6 @@ TESTS = \
   terminal.py \
   thread_restore.py
 
-XFAIL_TESTS = thread_restore.py
-
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -252,7 +252,10 @@ TESTS = \
   redzone.py \
   revert.py \
   pagecross.py \
-  terminal.py
+  terminal.py \
+  thread_restore.py
+
+XFAIL_TESTS = thread_restore.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/syscall_restart.c
+++ b/tests/syscall_restart.c
@@ -1,0 +1,81 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <libparameters.h>
+
+int
+main (void)
+{
+  char buffer[128] = "X";
+  ssize_t ret;
+
+  /* Signal readiness. */
+  printf ("Waiting for input.\n");
+
+  /*
+   * When a thread that is in the middle of a syscall receives a signal,
+   * the syscall gets interrupted. On some occasions, such as when there
+   * are no handlers registered for the signal, or when the SA_RESTART
+   * flag is in effect (see sigaction(2)), the kernel arranges an
+   * automatic restarting of the syscall to happen when the thread is
+   * rescheduled, and it does so by subtracting one instruction from the
+   * program counter.
+   *
+   * Notice, however, that the subtracting happens only immediately
+   * before the rescheduling, and it can't be easily detected from a
+   * tracer, such as gdb or libpulp's tools. The tracer sees a program
+   * counter that points to the next instruction after the syscall,
+   * i.e.: it doesn't see the subtraction.
+   *
+   * Now, since libpulp hijacks the target process, modifies the
+   * program counter of a selected thread, and asks the kernel to resume
+   * execution; the subtraction mechanism could be consumed, and the
+   * actual restarting of the syscall could be lost. If that happens,
+   * programs that do not handle syscall interruption would break.
+   * Besides, even if the change in behavior would not be catastrophic,
+   * it would make live patching less transparent.
+   *
+   * The following program intentionally exits in error if the read
+   * syscall is not restarted.
+   */
+  errno = 0;
+  ret = read (STDIN_FILENO, buffer, 1);
+
+  if (ret < 0) {
+    if (errno == EINTR) {
+      printf ("read syscall interrupted but not restarted.\n");
+    }
+    printf ("read syscall error code: %d", errno);
+    return 1; /* Libpulp should restart syscalls on its own. */
+  }
+  if (ret == 0) {
+    printf ("End of file.\n");
+    return 1; /* The test driver is not expected to send EOF. */
+  }
+
+  int_params (1, 2, 3, 4, 5, 6, 7, 8);
+  float_params (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  return 0; /* At least one byte was read. */
+}

--- a/tests/syscall_restart.py
+++ b/tests/syscall_restart.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+from tests import *
+
+# Start the test program and check default behavior
+child = pexpect.spawn('./' + testname, timeout=1, env=preload,
+                      encoding='utf-8')
+child.logfile = sys.stdout
+
+child.expect('Waiting for input.')
+print('Greeting... ok.')
+
+# After printing the greeting message, the target process makes a call
+# to fgets, which calls the read syscall. Applying a live patch will
+# interrupt the syscall.
+ret = subprocess.run([trigger, str(child.pid),
+                      'libparameters_livepatch1.ulp'])
+if ret.returncode:
+  print('Failed to apply livepatch #1 for libparameters')
+  exit(1)
+
+# Send a newline, which should be received by the read syscall if it has
+# been successfully restarted by libpulp. If the syscall has not been
+# restarted, the child program will exit without printing anything.
+child.sendline('')
+child.expect('8-7-6-5-4-3-2-1\r\n');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0\r\n');
+print('Syscall restarting... ok.')
+
+# Kill the child process and exit
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
There are multiple topics in this merge request, notably, a fix for thread context restoration and explanations about the transparency of syscall restarting by the kernel. Each contain a new test case. (see commit messages for explanations).