### PR TITLE
Avoid libbfd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,10 +19,6 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-if BUILD_ULP_TOOLS
-  MAYBE_TOOLS = tools
-endif
-
-SUBDIRS = include lib $(MAYBE_TOOLS) tests
+SUBDIRS = include lib tools tests
 
 EXTRA_DIST = LICENSE README

--- a/configure.ac
+++ b/configure.ac
@@ -83,12 +83,10 @@ fi
 ],[AC_MSG_ERROR([Unexpected configure error.])])
 
 # The following headers are required to build libpulp's tools.
-AC_CHECK_HEADERS([bfd.h gelf.h],
-[build_ulp_tools=yes],
-[build_ulp_tools=no; break])
-AM_CONDITIONAL([BUILD_ULP_TOOLS], [test "$build_ulp_tools" = "yes"])
-AS_IF([test "$build_ulp_tools" = "no"], AC_MSG_WARN([\
-Not building the tools because of missing headers.]))
+AC_CHECK_HEADER([bfd.h],,
+AC_MSG_ERROR([Binutils development files are missing.]))
+AC_CHECK_HEADER([gelf.h],,
+AC_MSG_ERROR([Libelf development files are missing.]))
 
 # Python and python's pexpect are required to run the tests.
 AM_PATH_PYTHON([3])

--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,6 @@ fi
 ],[AC_MSG_ERROR([Unexpected configure error.])])
 
 # The following headers are required to build libpulp's tools.
-AC_CHECK_HEADER([bfd.h],,
-AC_MSG_ERROR([Binutils development files are missing.]))
 AC_CHECK_HEADER([gelf.h],,
 AC_MSG_ERROR([Libelf development files are missing.]))
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -33,7 +33,7 @@ noinst_HEADERS = introspection.h ptrace.h packer.h
 noinst_LTLIBRARIES = libcommon.la
 
 libcommon_la_SOURCES = introspection.c ptrace.c
-libcommon_la_LIBADD = -lbfd -lz -liberty -ldl
+libcommon_la_LIBADD = -lelf -ldl
 
 # The dynsym_gate tool fills in the trampoline slots in the .ulp section
 # of live patchable libraries.

--- a/tools/check.c
+++ b/tools/check.c
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <link.h>
 #include <dirent.h>
-#include <bfd.h>
 #include <stddef.h>
 #include <fcntl.h>
 #include <sys/user.h>

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -20,7 +20,6 @@
  */
 
 #include <link.h>
-#include <bfd.h>
 
 #include "ptrace.h"
 
@@ -65,8 +64,6 @@ struct ulp_dynobj
 {
     char *filename;
     struct link_map link_map;
-    asymbol **symtab;
-    int symtab_len;
 
     Elf64_Addr trigger;
     Elf64_Addr check;
@@ -90,8 +87,6 @@ struct ulp_addresses
     Elf64_Addr global;
     Elf64_Addr local;
 };
-
-int parse_file_symtab(struct ulp_dynobj *obj, char needed);
 
 int dig_main_link_map(struct ulp_process *process);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <link.h>
 #include <dirent.h>
-#include <bfd.h>
 #include <stddef.h>
 #include <fcntl.h>
 #include <sys/user.h>


### PR DESCRIPTION
With these patches binutils-devel is no longer required and make check will not finish successfully if it didn't test anything.