### PR TITLE
Restore previous memory protection bits after live patching

### DIFF
--- a/include/ulp.h
+++ b/include/ulp.h
@@ -104,10 +104,6 @@ int ulp_apply_all_units(struct ulp_metadata *ulp);
 
 struct ulp_applied_patch *ulp_state_update(struct ulp_metadata *ulp);
 
-int set_write_tgt(void *tgt_addr);
-
-int set_exec_tgt(void *tgt_addr);
-
 int check_patch_sanity(struct ulp_metadata *ulp);
 
 int check_patch_dependencies(struct ulp_metadata *ulp);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -295,8 +295,7 @@ TESTS = \
   memory_protection.py
 
 XFAIL_TESTS = \
-  hidden.py \
-  memory_protection.py
+  hidden.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -96,6 +96,16 @@ libpagecross_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libpagecross.post
 
+# Target libraries to test memory access protections
+check_LTLIBRARIES += libaddress.la
+noinst_HEADERS += libaddress.h
+
+libaddress_la_SOURCES = libaddress.c $(TARGET_TRM_SOURCES)
+libaddress_la_CFLAGS = $(TARGET_CFLAGS)
+libaddress_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libaddress.post
+
 # Live patches
 check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
@@ -106,7 +116,8 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libparameters_livepatch1.la \
                      librecursion_livepatch1.la \
                      libblocked_livepatch1.la \
-                     libpagecross_livepatch1.la
+                     libpagecross_livepatch1.la \
+                     libaddress_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -138,6 +149,9 @@ libblocked_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libpagecross_livepatch1_la_SOURCES = libpagecross_livepatch1.c
 libpagecross_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libaddress_livepatch1_la_SOURCES = libaddress_livepatch1.c
+libaddress_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -168,7 +182,10 @@ METADATA = \
   libblocked_livepatch1.rev \
   libpagecross_livepatch1.dsc \
   libpagecross_livepatch1.ulp \
-  libpagecross_livepatch1.rev
+  libpagecross_livepatch1.rev \
+  libaddress_livepatch1.dsc \
+  libaddress_livepatch1.ulp \
+  libaddress_livepatch1.rev
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -180,7 +197,8 @@ EXTRA_DIST = \
   libparameters_livepatch1.in \
   librecursion_livepatch1.in \
   libblocked_livepatch1.in \
-  libpagecross_livepatch1.in
+  libpagecross_livepatch1.in \
+  libaddress_livepatch1.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -198,7 +216,8 @@ check_PROGRAMS = \
   pagecross \
   loop \
   terminal \
-  syscall_restart
+  syscall_restart \
+  memory_protection
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -254,6 +273,10 @@ terminal_SOURCES = terminal.c
 terminal_CFLAGS = -pthread $(AM_CFLAGS)
 terminal_DEPENDENCIES = $(POST_PROCESS) $(METADATA) loop
 
+memory_protection_SOURCES = memory_protection.c
+memory_protection_LDADD = libaddress.la
+memory_protection_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -268,9 +291,12 @@ TESTS = \
   terminal.py \
   thread_restore.py \
   syscall_restart.py \
-  hidden.py
+  hidden.py \
+  memory_protection.py
 
-XFAIL_TESTS = hidden.py
+XFAIL_TESTS = \
+  hidden.py \
+  memory_protection.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/libaddress.c
+++ b/tests/libaddress.c
@@ -1,0 +1,37 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void *
+get_return_address(void)
+{
+  void *result;
+
+  result = __builtin_return_address(0);
+  result = __builtin_extract_return_addr(result);
+
+  return result;
+}
+
+void *
+get_address(void)
+{
+  return get_return_address();
+}

--- a/tests/libaddress.h
+++ b/tests/libaddress.h
@@ -1,0 +1,22 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void *get_address(void);

--- a/tests/libaddress_livepatch1.c
+++ b/tests/libaddress_livepatch1.c
@@ -1,0 +1,28 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+
+void *
+new_get_address(void)
+{
+  return NULL;
+}

--- a/tests/libaddress_livepatch1.in
+++ b/tests/libaddress_livepatch1.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libaddress_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libaddress.so.0
+get_address:new_get_address

--- a/tests/memory_protection.c
+++ b/tests/memory_protection.c
@@ -1,0 +1,94 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <sys/mman.h>
+
+#include <libaddress.h>
+
+/* Do not optimize, otherwise the read/write sequence go away. */
+#pragma GCC push_options
+#pragma GCC optimize("O0")
+
+void
+disturb_memory(void *addr)
+{
+  int word;
+
+  word = *((int *)addr);
+  *((int *)addr) = word;
+}
+
+/* Restore optimization level. */
+#pragma GCC pop_options
+
+int
+main(void)
+{
+  char buffer[128];
+  int retcode;
+  unsigned long page_size;
+  uintptr_t page_mask;
+  void *page_addr;
+  void *addr;
+
+  page_size = getpagesize();
+  page_mask = ~(page_size - 1);
+
+  /* Get an address from the library. */
+  addr = get_address();
+
+  /* Enable writes to the code area. */
+  page_addr = (void *)((uintptr_t)addr & page_mask);
+  retcode = mprotect(page_addr, 1, PROT_READ | PROT_WRITE | PROT_EXEC);
+  if (retcode) {
+    perror("mprotect");
+    return 1;
+  }
+
+  /* Loop waiting for any input. */
+  printf("Waiting for input.\n");
+  while (1) {
+    if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+      if (errno) {
+        perror("memory_protection");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+
+    /* Read and write to the code area. */
+    disturb_memory(addr);
+
+    /* Use the library. */
+    if (get_address() == NULL)
+      printf("NULL\n");
+    else
+      printf("Non-NULL\n");
+  }
+
+  return 1;
+}

--- a/tests/memory_protection.py
+++ b/tests/memory_protection.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+from tests import *
+
+# Start the test program and check default behavior
+child = pexpect.spawn('./' + testname, timeout=1, env=preload,
+                      encoding='utf-8')
+
+child.expect('Waiting for input.')
+print('Greeting... ok.')
+
+# Every time a newline is sent, the test program touchs code memory
+print('Testing output before live patch... ', end='')
+child.sendline('')
+child.expect('Non-NULL\r\n');
+print('ok.')
+
+# Apply live patch
+print('Applying live patch... ', end='')
+ret = subprocess.run([trigger, str(child.pid),
+                      'libaddress_livepatch1.ulp'])
+if ret.returncode:
+  print('fail.')
+  exit(1)
+print('ok.')
+
+# Try to touch code memory after live patching
+print('Testing output after live patch... ', end='')
+child.sendline('')
+index = child.expect(['NULL\r\n', pexpect.EOF]);
+if index == 0:
+  print('ok.')
+if index == 1:
+  print('fail.')
+  if child.isalive() == False:
+    print('Test program is dead')
+  exit(1)
+
+# Kill the child process and exit
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
None of the examples I have built so far will be affected by this change, because the memory protection bits for code segments in all of them are always set to read and execute (the default that libpulp restores to). However, it is theoretically possible that applications change the protection configuration of their own memory, so this patch makes live patching more transparent.