### PR TITLE
Add support for unexported variables access in live patches

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -46,12 +46,15 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 	$(ULP_POST) .libs/lib$*.so
 	touch $@
 
-# These rules cause the livepatch metadata to be built.  The .ulp target
-# depends on check_LTLIBRARIES, because .la targets indirectly produce
-# the .so files they need (it is impossible to have .ulp targets depend
-# directly on .so files, because libtool does not create .so targets).
-%.dsc: %.in
-	sed -e "s|__ABS_BUILDDIR__|$(abs_builddir)|" $^ > $@
+# These rules cause the livepatch metadata to be built. The .ulp and
+# .dsc targets depends on check_LTLIBRARIES, because .la targets
+# indirectly produce the .so files they need (it is impossible to have
+# .ulp and .dsc targets depend directly on .so files, because libtool
+# does not create .so targets).
+%.dsc: %.in $(check_LTLIBRARIES)
+	sed -e "s|__ABS_BUILDDIR__|$(abs_builddir)|" $< > $*.tmp
+	$(top_srcdir)/tests/offsets.py $*.tmp $@
+	rm -f $*.tmp
 
 %.ulp: %.dsc $(check_LTLIBRARIES)
 	$(ULP_PACKER) $< -o $@

--- a/README.md
+++ b/README.md
@@ -172,10 +172,17 @@ written with the following syntax:
 2: @<absolute path of the targeted library>
 3: <old_fname_1>:<new_fname_1>
 4: <old_fname_2>:<new_fname_2>
+5: #<var1>:<var1ref>:<var1_offset>:<var1ref_offset>
+6: #<var2>:<var2ref>:<var2_offset>:<var2ref_offset>
 ...
 ```
 
-Line 1 brings the absolute path of a .so file that contains all the functions
-which will be used to replace functions in the running process. Line 2 brings
-the absolute path for the library that will be patched and must be preceded by
-an '@'. The following lines bring pairs of replaced and replacing functions.
+Line 1 provides the absolute path of a .so file that contains all the functions
+which will be used to replace functions in the running process. Line 2 provides
+the absolute path for the library that will be patched; it must be preceded by
+'@'. Lines 3 and 4 specify pairs of replaced and replacing functions (there
+could be more lines if more functions need replacing). Lines 5 and 6 specify
+the offsets that local (not-exported) variables in the target library have from
+the beginning of the library load location, as well as the offsets of
+references to those variables in the live patch object. These offsets are used
+by Libpulp to enable access to local variables from the live patch.

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -48,6 +48,8 @@ struct ulp_metadata
   struct ulp_object *objs;
   uint32_t ndeps;
   struct ulp_dependency *deps;
+  uint32_t nrefs;
+  struct ulp_reference *refs;
   uint8_t type;
 };
 
@@ -76,6 +78,15 @@ struct ulp_dependency
   unsigned char dep_id[32];
   char patch_id_check;
   struct ulp_dependency *next;
+};
+
+struct ulp_reference
+{
+  char *target_name;
+  char *reference_name;
+  uintptr_t target_offset;
+  uintptr_t patch_offset;
+  struct ulp_reference *next;
 };
 
 #endif

--- a/man/libpulp.7
+++ b/man/libpulp.7
@@ -133,11 +133,23 @@ recorded in the metadata file as a list of pairs of functions.
 .B Description file format
 The metadata file is created based on a description file. The description file
 is rather simple. The first line contains the absolute path to the live patch
-DSO. The second line starts with the '@' character, immediately followed by the
-absolute path to the target library DSO. Finally, all following lines provide
-the list of replacement functions, where each line starts with the name of the
-original function, followed by a colon, then by the name of the replacement
-function.
+DSO. The second line starts with the
+.I @
+character, immediately followed by the absolute path to the target library DSO.
+Subsequent lines, when not preceded by the
+.I #
+character, provide the list of replacement functions, where each line starts
+with the name of the original function, followed by a colon, then by the
+name of the replacement function. Finally, subsequent lines that do start with
+.I #
+specify the offsets that local (not-exported) variables in the target library
+have from the beginning of the library load location, as well as the offsets of
+references to those variables in the live patch object. Each line is composed
+of four items separated by colons: the name of the variable in the target
+library; the name of a reference to it in the live patch object; the offset of
+the library variable within the library DSO; the offset of the reference
+variable within the live patch DSO. These offsets are used by Libpulp to enable
+access to local variables from the live patch.
 .IP
 For example, a live patch to the math library could have a description file
 that looked like the following snippet (paths may differ across distributions):
@@ -150,6 +162,8 @@ that looked like the following snippet (paths may differ across distributions):
 hypot:hypot_v2
 gamma:new_gamma
 atan:atan_new
+#narenas:ulpr_narenas:00000000001c2720:0000000000004020
+#main_arena:ulpr_main_arena:00000000001c3a00:0000000000004060
 .EE
 .RE
 .PP

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -136,6 +136,16 @@ libexception_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libexception.post
 
+# Target libraries to test static data access
+check_LTLIBRARIES += libaccess.la
+noinst_HEADERS += libaccess.h
+
+libaccess_la_SOURCES = libaccess.c
+libaccess_la_CFLAGS = $(TARGET_CFLAGS)
+libaccess_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libaccess.post
+
 # Live patches
 check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
@@ -149,7 +159,8 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libblocked_livepatch1.la \
                      libpagecross_livepatch1.la \
                      libaddress_livepatch1.la \
-                     libcontract_livepatch1.la
+                     libcontract_livepatch1.la \
+                     libaccess_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -190,6 +201,9 @@ libaddress_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libcontract_livepatch1_la_SOURCES = libcontract_livepatch1.c
 libcontract_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libaccess_livepatch1_la_SOURCES = libaccess_livepatch1.c
+libaccess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -229,7 +243,10 @@ METADATA = \
   libaddress_livepatch1.rev \
   libcontract_livepatch1.dsc \
   libcontract_livepatch1.ulp \
-  libcontract_livepatch1.rev
+  libcontract_livepatch1.rev \
+  libaccess_livepatch1.dsc \
+  libaccess_livepatch1.ulp \
+  libaccess_livepatch1.rev
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -244,7 +261,8 @@ EXTRA_DIST = \
   libblocked_livepatch1.in \
   libpagecross_livepatch1.in \
   libaddress_livepatch1.in \
-  libcontract_livepatch1.in
+  libcontract_livepatch1.in \
+  libaccess_livepatch1.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -267,7 +285,8 @@ check_PROGRAMS = \
   constructor \
   cancel \
   contract \
-  exception_handling
+  exception_handling \
+  access
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -346,6 +365,10 @@ exception_handling_SOURCES = exception_handling.cc
 exception_handling_LDADD = libexception.la
 exception_handling_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+access_SOURCES = access.c
+access_LDADD = libaccess.la
+access_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -365,7 +388,8 @@ TESTS = \
   cancel.py \
   contract.py \
   exception_handling.py \
-  missing_function.py
+  missing_function.py \
+  access.py
 
 XFAIL_TESTS = \
   blocked.py \
@@ -379,4 +403,6 @@ PY_LOG_COMPILER = $(PYTHON) -B
 EXTRA_DIST += $(TESTS)
 
 # Common definitions and imports for all test cases
-EXTRA_DIST += testsuite.py
+EXTRA_DIST += \
+  testsuite.py \
+  offsets.py

--- a/tests/access.c
+++ b/tests/access.c
@@ -1,0 +1,57 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libaccess.h>
+
+int
+main(void)
+{
+  char buffer[128];
+
+  /* Original banner. */
+  printf("%s\n", banner_get());
+
+  /* Use original banner setting function. */
+  banner_set(strdup("Banner changed from main"));
+  printf("%s\n", banner_get());
+
+  /* Wait for input. */
+  if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+    if (errno) {
+      perror("access");
+      return 1;
+    }
+  }
+
+  /*
+   * Use banner setting function again, which is supposed to have been
+   * changed by the test driver. The patched function ignores the
+   * argument, so 'String from main' should not be in the output.
+   */
+  banner_set("String from main");
+  printf("%s\n", banner_get());
+
+  return 0;
+}

--- a/tests/access.py
+++ b/tests/access.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn(testsuite.testname)
+
+child.expect('Original banner')
+child.expect('Banner changed from main')
+
+child.livepatch('libaccess_livepatch1.ulp')
+
+child.sendline('')
+child.expect('String from live patch',
+             reject=['String from main',
+                     'Live patch data references not initialized'])
+
+child.close(force=True)
+exit(0)

--- a/tests/libaccess.c
+++ b/tests/libaccess.c
@@ -1,0 +1,38 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include <libaccess.h>
+
+static char *banner = "Original banner";
+
+char *
+banner_get(void)
+{
+  return banner;
+}
+
+void
+banner_set(char *new)
+{
+  banner = new;
+}

--- a/tests/libaccess.h
+++ b/tests/libaccess.h
@@ -1,0 +1,23 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+char *banner_get(void);
+void banner_set(char *);

--- a/tests/libaccess_livepatch1.c
+++ b/tests/libaccess_livepatch1.c
@@ -1,0 +1,47 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+
+#include <libaccess.h>
+
+static char **ulpr_banner = NULL;
+static char *ulpr_string = "String from live patch";
+
+void
+new_banner_set(__attribute__((unused)) char *new)
+{
+  if (ulpr_banner == NULL)
+    errx(EXIT_FAILURE, "Live patch data references not initialized");
+
+  *ulpr_banner = ulpr_string;
+}
+
+/*
+ * Touch ulpr_banner so that it does not get optimized away or placed into
+ * read-only sections.
+ */
+void
+banner_disturb(void)
+{
+  ulpr_banner++;
+}

--- a/tests/libaccess_livepatch1.in
+++ b/tests/libaccess_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libaccess_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libaccess.so.0
+banner_set:new_banner_set
+#banner:ulpr_banner:__TARGET_OFFSET__:__PATCH_OFFSET__

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+
+def find_offset(file, name):
+  nm = subprocess.Popen(['nm', file], stdout=subprocess.PIPE,
+                        encoding='utf-8')
+  for entry in nm.stdout.readlines():
+    split = entry.split(sep=' ')
+    symbol = split[2].rstrip('\n')
+    if symbol == name:
+      return split[0]
+  return
+
+# This program takes two arguments, first the path to the input file, then the
+# path to the output file. The input file is a live patch description template,
+# where every line starting with '#' contains a local (not-exported) variable
+# whose address in the target library (__TARGET_OFFSET__), as well as the
+# address of its reference in the live patch (__PATCH_OFFSET__) must be
+# determined.
+parser = argparse.ArgumentParser()
+parser.add_argument('ifile')
+parser.add_argument('ofile')
+args = parser.parse_args()
+
+ifile = open(args.ifile, 'r')
+ofile = open(args.ofile, 'w')
+
+# The path to the patch file is always at the first line
+patch = ifile.readline()
+patch = patch.rstrip('\n')
+
+# The path to the target library is always at the second line,
+# which always starts with '@'
+target = ifile.readline()
+target = target.rstrip('\n')
+target = target.lstrip('@')
+
+# Rewind the input file
+ifile.seek(0)
+
+# Iterate over all lines of the input file
+for line in ifile:
+
+  # Lines starting with '#' contain local variables
+  if line[0] == '#':
+
+    # Parse the line
+    split = line.lstrip('#')
+    split = split.split(':')
+
+    # Get the name of the local variable in the target library
+    tname = split[0]
+
+    # Get the name of the local variable reference in the live patch
+    pname = split[1]
+
+    # Search for the local variable in the target library
+    toff = find_offset(target, tname)
+
+    # Search for the local variable reference in the live patch
+    poff = find_offset(patch, pname)
+
+    # Replace offset template patterns with actual offsets
+    line = line.replace('__TARGET_OFFSET__', toff)
+    line = line.replace('__PATCH_OFFSET__', poff)
+
+  # Write every line back to the output file
+  ofile.write(line)
+
+ifile.close()
+ofile.close()


### PR DESCRIPTION
Read the commit message for more information...

Apart from that, the patch adds new information to the live patch metadata, more specifically, the addresses (offsets from the load address) of data objects, and that means that there is no need to open in-disk files (DSOs) during live patch application to fix references to LOCAL objects.

We should probably copy this mechanism to the other parts of the live patch metadata, so that, in the future, nothing else depends on the target library file being both in-disk and in the exact same version that the target process used (which doesn´t work after package updates).