### PR TITLE
Skip function version selection routine in runtime

### DIFF
--- a/include/ulp.h
+++ b/include/ulp.h
@@ -115,7 +115,8 @@ int check_build_id(struct ulp_metadata *ulp);
 
 void ulp_patch_addr_absolute(void *old_faddr, void *new_faddr);
 
-int ulp_patch_addr(void *old_faddr, unsigned int index);
+int ulp_patch_addr(void *old_faddr, void *new_faddr, unsigned int index,
+                   int enable);
 
 struct ulp_applied_patch *ulp_get_applied_patch(unsigned char *id);
 

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <link.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,12 +46,12 @@ struct ulp_detour_root *__ulp_root = NULL;
 
 char ulp_prologue[ULP_NOPS_LEN] = {
   // Preceding nops
-  0x57,                         // push    %rdi
-  0x48, 0xc7, 0xc7, 0, 0, 0, 0, // movq    $index, %rdi
+  0x57,                         // push    %rdi           <-- Unused
+  0x48, 0xc7, 0xc7, 0, 0, 0, 0, // movq    $index, %rdi   <-- Unused
   0xff, 0x25, 0, 0, 0, 0,       // jmp     0x0(%rip)
   0, 0, 0, 0, 0, 0, 0, 0,       // <data>  &__ulp_prolog
   // Function entry is here
-  0xeb, -(PRE_NOPS_LEN + 2) // jump above
+  0xeb, -(PRE_NOPS_LEN - 8 + 2) // jump above
 };
 
 unsigned int __ulp_root_index_counter = 0;
@@ -645,7 +646,7 @@ ulp_apply_all_units(struct ulp_metadata *ulp)
       return 0;
     }
 
-    if (!(ulp_patch_addr(old_fun, root->index))) {
+    if (!(ulp_patch_addr(old_fun, new_fun, root->index, true))) {
       WARN("error patching address %p", old_fun);
       return 0;
     }
@@ -915,6 +916,25 @@ ulp_patch_prologue_layout(void *old_fentry, unsigned int function_index)
   memcpy(old_fentry + 4, &function_index, 4);
 }
 
+/*
+ * When a function gets live patch, the nops at its entry point get replaced
+ * with a backwards-jump to a small segment of code that redirects execution to
+ * the new version of the function. However, when all live patches to said
+ * function are deactivated (because the live patches have been reversed), the
+ * need for the backwards-jump is gone.
+ *
+ * The following function replaces the backwards-jump with nops, thus making
+ * the target function look like it did at the beginning of execution, i.e.
+ * without live patches.
+ */
+void
+ulp_skip_prologue(void *fentry)
+{
+  /* Do not jump backwards on function entry (0x6690 is a nop on x86). */
+  memset(fentry + 0, 0x66, 1);
+  memset(fentry + 1, 0x90, 1);
+}
+
 void
 __ulp_manage_universes(unsigned long idx)
 {
@@ -986,7 +1006,8 @@ ulp_patch_addr_absolute(void *old_fentry, void *manager)
 }
 
 int
-ulp_patch_addr(void *old_faddr, unsigned int index)
+ulp_patch_addr(void *old_faddr, void *new_faddr, unsigned int index,
+               int enable)
 {
   void *addr;
   unsigned long page_size;
@@ -1036,8 +1057,13 @@ ulp_patch_addr(void *old_faddr, unsigned int index)
   }
 
   /* Actually patch the prologue. */
-  ulp_patch_prologue_layout(addr, index);
-  ulp_patch_addr_absolute(addr, &__ulp_prologue);
+  if (enable) {
+    ulp_patch_prologue_layout(addr, index);
+    ulp_patch_addr_absolute(addr, new_faddr);
+  }
+  else {
+    ulp_skip_prologue(old_faddr);
+  }
 
   /* Restore the previous access protection. */
   if (mprotect((void *)page1, page_size, prot1)) {
@@ -1131,11 +1157,33 @@ ulp_revert_all_units(unsigned char *patch_id)
 {
   struct ulp_detour_root *r;
   struct ulp_detour *d;
+  struct ulp_detour *d2;
+  struct ulp_detour *dactive;
 
   for (r = __ulp_root; r != NULL; r = r->next)
     for (d = r->detours; d != NULL; d = d->next)
-      if (memcmp(d->patch_id, patch_id, 32) == 0)
+      if (memcmp(d->patch_id, patch_id, 32) == 0) {
+
+        /* Deactivate this patch. */
         d->active = 0;
+
+        /* Find the most recent live patch that is active. */
+        dactive = NULL;
+        for (d2 = r->detours; d2 != NULL; d2 = d2->next) {
+          if (d2->active) {
+            dactive = d2;
+            /* Newest elements of the list come first. */
+            break;
+          }
+        }
+
+        /* Update the function prologue. */
+        if (dactive == NULL)
+          ulp_patch_addr(r->patched_addr, NULL, 0, false);
+        else
+          ulp_patch_addr(r->patched_addr, dactive->target_addr, r->index,
+                         true);
+      }
 
   return 1;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -141,6 +141,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
                      libhundreds_livepatch1.la \
                      libhundreds_livepatch2.la \
+                     libhundreds_livepatch3.la \
                      libdozens_bsymbolic_livepatch1.la \
                      libhundreds_bsymbolic_livepatch1.la \
                      libparameters_livepatch1.la \
@@ -162,6 +163,9 @@ libhundreds_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libhundreds_livepatch2_la_SOURCES = libhundreds_livepatch2.c
 libhundreds_livepatch2_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+libhundreds_livepatch3_la_SOURCES = libhundreds_livepatch3.c
+libhundreds_livepatch3_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libdozens_bsymbolic_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_bsymbolic_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -203,6 +207,9 @@ METADATA = \
   libhundreds_livepatch2.dsc \
   libhundreds_livepatch2.ulp \
   libhundreds_livepatch2.rev \
+  libhundreds_livepatch3.dsc \
+  libhundreds_livepatch3.ulp \
+  libhundreds_livepatch3.rev \
   libdozens_bsymbolic_livepatch1.dsc \
   libdozens_bsymbolic_livepatch1.ulp \
   libdozens_bsymbolic_livepatch1.rev \
@@ -236,6 +243,7 @@ EXTRA_DIST = \
   libdozens_livepatch99.in \
   libhundreds_livepatch1.in \
   libhundreds_livepatch2.in \
+  libhundreds_livepatch3.in \
   libdozens_bsymbolic_livepatch1.in \
   libhundreds_bsymbolic_livepatch1.in \
   libparameters_livepatch1.in \

--- a/tests/libhundreds_livepatch3.c
+++ b/tests/libhundreds_livepatch3.c
@@ -1,0 +1,26 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+int
+four_hundreds(void)
+{
+  return 400;
+}

--- a/tests/libhundreds_livepatch3.in
+++ b/tests/libhundreds_livepatch3.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libhundreds_livepatch3.so
+@__ABS_BUILDDIR__/.libs/libhundreds.so.0
+hundred:four_hundreds

--- a/tests/revert.py
+++ b/tests/revert.py
@@ -38,15 +38,25 @@ child.livepatch('libhundreds_livepatch2.ulp')
 child.sendline('hundred')
 child.expect('300', reject=['100', '200'])
 
+child.livepatch('libhundreds_livepatch3.ulp')
+
+child.sendline('hundred')
+child.expect('400', reject=['100', '200', '300'])
+
 child.livepatch('libhundreds_livepatch2.rev')
 
 child.sendline('hundred')
-child.expect('200', reject=['100', '300'])
+child.expect('400', reject=['100', '200', '300'])
+
+child.livepatch('libhundreds_livepatch3.rev')
+
+child.sendline('hundred')
+child.expect('200', reject=['100', '300', '400']);
 
 child.livepatch('libhundreds_livepatch1.rev')
 
 child.sendline('hundred')
-child.expect('100', reject=['200', '300']);
+child.expect('100', reject=['200', '300', '400']);
 
 child.close(force=True)
 exit(0)


### PR DESCRIPTION
See commit messages for more details...

Although I haven't measured performance, this change obviously improve it, since it removes a whole function from the execution path.