### PR TITLE
Rm libname path check (#26)

### DIFF
--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -394,9 +394,6 @@ parse_lib_dynobj(struct ulp_process *process, struct link_map *link_map_addr)
     return NULL;
   }
 
-  if (libname[0] != '/')
-    return link_map;
-
   DEBUG("reading in-memory information about %s.", libname);
 
   obj->filename = libname;


### PR DESCRIPTION
Fix implicit reliance on first character in dynamic object file path
being '/'. Previously, specifying LD_PRELOAD=<relative_path_to>/libpulp.so
wouldn't work, unless the relative path was prepended with the full path to the
cwd.