### PR TITLE
Check if function exists in container file before applying livepatch

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -394,8 +394,7 @@ TESTS = \
 XFAIL_TESTS = \
   blocked.py \
   contract.py \
-  hidden.py \
-  missing_function.py
+  hidden.py
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/missing_function.py
+++ b/tests/missing_function.py
@@ -20,19 +20,21 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
-
 import testsuite
+
+livepatch_metadata  = 'libparameters_livepatch2.ulp'
+livepatch_container = 'libparameters_livepatch2.so'
 
 child = testsuite.spawn('parameters')
 
 child.expect('Waiting for input.')
 
-errors = 0
+errors = 1
 try:
-  child.livepatch('libparameters_livepatch2.ulp')
+  child.livepatch(livepatch_metadata)
 except subprocess.CalledProcessError:
-  child.expect('Unable to load function')
-  raise
+  if not child.is_so_loaded(livepatch_container):
+    errors = 0
 
 child.close(force=True)
 exit(errors)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -245,3 +245,12 @@ class spawn(pexpect.spawn):
     # Whereas on failure, the checker tool returns something different,
     # usually -1, so raise CalledProcessError.
     raise subprocess.CalledProcessError
+
+  def is_so_loaded(self, fname_so):
+    mapsf = open('/proc/' + str(self.pid) + '/maps', 'r')
+    maps = mapsf.read()
+    mapsf.close()
+
+    if maps.find(fname_so) == -1:
+      return False
+    return True


### PR DESCRIPTION
Previously, the ulp_trigger did not check if the function in the
livepatch container exists before loading the container file and
trying to "replace" the old function.  This commit fixes this by
checking if every function is present in the container file.

Fixes #24  

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>