### PR TITLE
Avoid opening libdl.so to interpose dlsym

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -23,7 +23,6 @@ libpulp_la_SOURCES = ulp.c interpose.c ulp_prologue.S ulp_interface.S
 libpulp_la_DEPENDENCIES= libpulp.versions
 libpulp_la_LDFLAGS = \
   -ldl \
-  -lelf \
   -Wl,--version-script=$(srcdir)/libpulp.versions \
   $(AM_LDFLAGS)
 


### PR DESCRIPTION
Previously, libpulp opened and parsed the ELF content of libdl.so file
to find the address to dlsym to interpose it. Instead of relying on the
.so file, we parsed the alreay loaded ELF program header structures that
is in the program memory to find the address to dlsym.

This commit also removes the requirement of libelf from libpulp.so, but
the tools still require it.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>