### PR TITLE
Message queue system

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,4 +17,4 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-noinst_HEADERS = ulp.h ulp_common.h interpose.h
+noinst_HEADERS = ulp.h ulp_common.h interpose.h msg_queue.h

--- a/include/msg_queue.h
+++ b/include/msg_queue.h
@@ -1,0 +1,74 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MSGQ_H
+#define MSGQ_H
+
+/* Define a 2Mb buffer for holding the messages.  */
+#define MSGQ_BUFFER_MAX (2 * 1024 * 1024)
+
+/* This is the circular message queue datastructure.
+ *
+ * It works on a fixed-size buffer and operates maintaining three variables:
+ *
+ *  - Top.
+ *  - Bottom.
+ *  - Distance.
+ *
+ * Take the following illustration as example, after inserting the strings:
+ *
+ *   - hhhhhhhhhhhhhh.
+ *   - iiiiii
+ *   - jjjjjjj
+ *
+ * Which will get the queue in the following state:
+ *
+ *  hhhhhhhhhhhhhh.iiiiii.jjjjjjj...
+ *  B                             T
+ *
+ * Where 'B' represents the bottom position, 'T' represents the top position,
+ * and the '.' represents the \0 character.
+ *
+ * If we insert the string 'kkkkkkk' next, notice that there is not enough
+ * space in the buffer for it, so 'T' wraps back to the beginning of the queue,
+ * overwrite part of the sequence of 'h', increments 'B', and write the message
+ * in the opened space, which results in the following state:
+ *
+ *  kkkkkkk.hhhhhh.iiiiii.jjjjjjj...
+ *          T      B
+ *
+ * resulting in the circular queue behaviour. When reading this queue, the user
+ * should start reading from the bottom position.
+ */
+struct msg_queue
+{
+  char buffer[MSGQ_BUFFER_MAX]; /* Buffer holding the messages.  */
+  int top;      /* Position pointing to free memory that can be written to.  */
+  int bottom;   /* Position pointing to the oldest message still in buffer.  */
+  int distance; /* Distance betweem top and bottom.  Should not be greater than
+                   MSGQ_BUFFER_MAX.  */
+};
+
+extern struct msg_queue __ulp_msg_queue;
+
+void msgq_push(const char *format, ...);
+
+#endif /* MSGQ_H */

--- a/include/msg_queue.h
+++ b/include/msg_queue.h
@@ -71,4 +71,8 @@ extern struct msg_queue __ulp_msg_queue;
 
 void msgq_push(const char *format, ...);
 
+/* Warn message using the message queue.  */
+
+#define MSGQ_WARN(fmt, ...) msgq_push("ulp: " fmt "\n", ##__VA_ARGS__)
+
 #endif /* MSGQ_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,7 +19,7 @@
 
 lib_LTLIBRARIES = libpulp.la
 
-libpulp_la_SOURCES = ulp.c interpose.c ulp_prologue.S ulp_interface.S
+libpulp_la_SOURCES = ulp.c interpose.c msg_queue.c ulp_prologue.S ulp_interface.S
 libpulp_la_DEPENDENCIES= libpulp.versions
 libpulp_la_LDFLAGS = \
   -ldl \

--- a/lib/msg_queue.c
+++ b/lib/msg_queue.c
@@ -1,0 +1,108 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "msg_queue.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Create an externally visible msg_queue object that will be read with ptrace.
+ * It will be read by ulp_messages (tools/messages.c) using ptrace. */
+
+struct msg_queue __ulp_msg_queue;
+
+/* Push a message into the message queue.
+ *
+ * @param format - printf like string.
+ * */
+
+void
+msgq_push(const char *format, ...)
+{
+  static char msg[MSGQ_BUFFER_MAX];
+
+  va_list arglist;
+  int msg_size;
+
+  /* Write the msg_queue values in variables for briefness.  */
+  int top = __ulp_msg_queue.top;
+  int bottom = __ulp_msg_queue.bottom;
+  int distance = __ulp_msg_queue.distance;
+  char *buffer = __ulp_msg_queue.buffer;
+
+  /* Expand the format string with the arguments provided. vsnprintf will
+   * return the size of the string, therefore, the size of the object will
+   * be +1 because of the null character in the end of the string.  */
+  va_start(arglist, format);
+  msg_size = vsnprintf(msg, MSGQ_BUFFER_MAX, format, arglist) + 1;
+  va_end(arglist);
+
+  /* In case the message is empty or it is too large for the buffer, don't
+   * bother even trying to insert it.  */
+  if (*msg == '\0' || msg_size > MSGQ_BUFFER_MAX)
+    return;
+
+  /* To understand what the `top` and `bottom` means, read messages.h in the
+   * include folder.
+   *
+   * Here, in case the message would not fit the available space in the end
+   * of the queue, insert it in the beginning, and account for this jump.
+   */
+  if (top + msg_size >= MSGQ_BUFFER_MAX) {
+    memset(&buffer[top], '\0', MSGQ_BUFFER_MAX - top);
+    distance += MSGQ_BUFFER_MAX - top;
+    top = 0;
+  }
+
+  /* Remember that this is a circular queue. Therefore, the distance between
+   * top and bottom should not pass the size of the queue, else we have a
+   * buffer overflow. In case when inserting the message would make the top
+   * marker overlap the bottom marker, we must eliminate the first
+   * inserted contents from the buffer.  This basically means that the bottom
+   * should move towards the top until enough space is available.  */
+  while (distance + msg_size >= MSGQ_BUFFER_MAX) {
+    int travel = strlen(&buffer[bottom]) + 1;
+    bottom = (bottom + travel) % MSGQ_BUFFER_MAX;
+
+    /* We may have reached a sequence of null characters because of the top
+     * being set to zero, which makes the end of the buffer to be filled with
+     * null characters.  Account for this too.  */
+    while (buffer[bottom] == '\0') {
+      bottom = (bottom + 1) % MSGQ_BUFFER_MAX;
+      travel++;
+    }
+
+    distance -= travel;
+  }
+
+  /* Finally, commit the message to the buffer.  */
+  memcpy(&buffer[top], msg, msg_size);
+
+  /* Update other structures.  */
+  distance += msg_size;
+  top = (top + msg_size) % MSGQ_BUFFER_MAX;
+
+  __ulp_msg_queue.top = top;
+  __ulp_msg_queue.bottom = bottom;
+  __ulp_msg_queue.distance = distance;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -420,7 +420,8 @@ TESTS = \
   exception_handling.py \
   missing_function.py \
   access.py \
-  buildid.py
+  buildid.py \
+  libpulp_messages.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/libpulp_messages.py
+++ b/tests/libpulp_messages.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('parameters')
+
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+try:
+  msgs = child.get_libpulp_messages()
+  if msgs.find("libpulp loaded") != -1:
+    error = 0
+except:
+  error = 1
+
+child.close(force=True)
+exit(error)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -252,3 +252,18 @@ class spawn(pexpect.spawn):
     if maps.find(fname_so) == -1:
       return False
     return True
+
+  # Get libpulp messages, currently by calling ulp_messages and parsing
+  # its stdout.
+  def get_libpulp_messages(self):
+    self.sanity(pid=self.pid)
+    command = [ulptool, 'messages', '-p', str(self.pid)]
+
+    try:
+      self.print('Checking libpulp.so messages.')
+      tool = subprocess.run(command, timeout=10, stdout=subprocess.PIPE)
+    except:
+      raise
+
+    msgs = tool.stdout.decode()
+    return str(msgs)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -30,7 +30,8 @@ noinst_HEADERS = \
   patches.h \
   dump.h \
   post.h \
-  revert.h
+  revert.h \
+  messages.h
 
 # Static library shared among the tools.
 
@@ -48,8 +49,8 @@ ulp_SOURCES = \
   md4.c \
   trigger.c \
   post.c \
-  revert.c
-
+  revert.c \
+  messages.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -413,10 +413,11 @@ parse_lib_dynobj(struct ulp_process *process, struct link_map *link_map_addr)
   obj->check = get_loaded_symbol_addr(obj, "__ulp_check_patched");
   obj->state = get_loaded_symbol_addr(obj, "__ulp_state");
   obj->global = get_loaded_symbol_addr(obj, "__ulp_get_global_universe");
+  obj->msg_queue = get_loaded_symbol_addr(obj, "__ulp_msg_queue");
 
   /* libpulp must expose all these symbols. */
   if (obj->trigger && obj->path_buffer && obj->check && obj->state &&
-      obj->global) {
+      obj->global && obj->msg_queue) {
     obj->next = NULL;
     process->dynobj_libpulp = obj;
     DEBUG("(libpulp found)");

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -99,6 +99,7 @@ struct ulp_dynobj
   Elf64_Addr path_buffer;
   Elf64_Addr state;
   Elf64_Addr global;
+  Elf64_Addr msg_queue;
 
   struct thread_state *thread_states;
 

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -1,0 +1,149 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <argp.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <link.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/user.h>
+#include <unistd.h>
+
+#include "arguments.h"
+#include "config.h"
+#include "introspection.h"
+#include "messages.h"
+#include "msg_queue.h"
+#include "ulp_common.h"
+
+static Elf64_Addr
+get_msgq_address(const struct ulp_process *p)
+{
+  struct ulp_dynobj *dyn;
+  Elf64_Addr msgq_addr = 0;
+
+  for (dyn = p->dynobj_libpulp; dyn != NULL; dyn = dyn->next) {
+    if (dyn->msg_queue) {
+      msgq_addr = dyn->msg_queue;
+      break;
+    }
+  }
+
+  return msgq_addr;
+}
+
+static void
+msgq_print(struct msg_queue *msg_queue)
+{
+  int bottom = msg_queue->bottom;
+  int distance = msg_queue->distance;
+
+  while (distance > 0) {
+    putchar(msg_queue->buffer[bottom]);
+    bottom = (bottom + 1) % MSGQ_BUFFER_MAX;
+    distance--;
+  }
+}
+
+static void
+msgq_debug(struct msg_queue *msg_queue)
+{
+  int i;
+  for (i = 0; i < MSGQ_BUFFER_MAX; i++) {
+    if (msg_queue->buffer[i] == '\0')
+      putchar('.');
+    else
+      putchar(msg_queue->buffer[i]);
+  }
+  putchar('\n');
+
+  for (i = 0; i < MSGQ_BUFFER_MAX; i++) {
+    if (msg_queue->bottom == i)
+      putchar('B');
+    else if (msg_queue->top == i)
+      putchar('T');
+    else
+      putchar(' ');
+  }
+  putchar('\n');
+}
+
+static int
+print_message_buffer(const struct ulp_process *p, bool debug)
+{
+  static struct msg_queue msg_queue;
+  int ret;
+
+  Elf64_Addr msgq_addr = get_msgq_address(p);
+
+  memset(&msg_queue, 0, sizeof(struct msg_queue));
+
+  if (!msgq_addr) {
+    WARN("could not find libpulp.so message queue in process %d.", p->pid);
+    return 1;
+  }
+
+  ret = read_memory((void *)&msg_queue, sizeof(struct msg_queue), p->pid,
+                    msgq_addr);
+  if (ret > 0) {
+    WARN("could not read libpulp.so message queue in process %d.", p->pid);
+    return 1;
+  }
+
+  if (debug)
+    msgq_debug(&msg_queue);
+  else
+    msgq_print(&msg_queue);
+
+  return ret;
+}
+
+int
+run_messages(struct arguments *arguments)
+{
+  int ret;
+  struct ulp_process target;
+
+  /* Set the verbosity level in the common introspection infrastructure. */
+  ulp_verbose = arguments->verbose;
+  ulp_quiet = arguments->quiet;
+
+  memset(&target, 0, sizeof(target));
+  target.pid = arguments->pid;
+  ret = initialize_data_structures(&target);
+  if (ret) {
+    WARN("error gathering target process information.");
+    return 1;
+  }
+
+  ret = print_message_buffer(&target, false);
+  if (ret > 0) {
+    WARN("message queue reading failed.");
+    return 1;
+  }
+
+  return 0;
+}

--- a/tools/messages.h
+++ b/tools/messages.h
@@ -19,41 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef MESSAGES_H
+#define MESSAGES_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
+int run_messages(struct arguments *);
 
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-  ULP_REVERSE,
-  ULP_MESSAGES,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  pid_t pid;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid_only;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
-
-#endif
+#endif /* MESSAGES.H */

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "dump.h"
 #include "introspection.h"
+#include "messages.h"
 #include "packer.h"
 #include "patches.h"
 #include "post.h"
@@ -63,7 +64,8 @@ static const char doc[] =
 "   trigger                   Applies the live patch in ARG1 to the process\n"
 "                             with PID\n"
 "   post                      Post process patch container (.so file) in ARG1.\n"
-"   reverse                   Create reverse livepatch from metadata in ARG1.\n";
+"   reverse                   Create reverse livepatch from metadata in ARG1.\n"
+"   messages                  Print livepatch information contained in libpulp.\n";
 
 /* clang-format on */
 
@@ -113,7 +115,7 @@ command_from_string(const char *str)
     { "patches", ULP_PATCHES }, { "check", ULP_CHECK },
     { "dump", ULP_DUMP },       { "packer", ULP_PACKER },
     { "trigger", ULP_TRIGGER }, { "post", ULP_POST },
-    { "reverse", ULP_REVERSE },
+    { "reverse", ULP_REVERSE }, { "messages", ULP_MESSAGES },
   };
 
   size_t i;
@@ -168,6 +170,11 @@ handle_end_of_arguments(const struct argp_state *state)
         argp_error(state,
                    "METADATA path must be shorter than %d bytes; got %d.",
                    ULP_PATH_LEN, path_length);
+      break;
+
+    case ULP_MESSAGES:
+      if (arguments->pid == 0)
+        argp_error(state, "pid is mandatory in 'messages' comamnd.");
       break;
   }
 }
@@ -279,6 +286,10 @@ main(int argc, char **argv)
 
     case ULP_REVERSE:
       ret = run_reverse(&arguments);
+      break;
+
+    case ULP_MESSAGES:
+      ret = run_messages(&arguments);
       break;
   }
 


### PR DESCRIPTION
This PR add support to a circular queue system to hold the libpulp messages instead of writing them directly to `stdout`/`stderr`'s target process, and a new tool named `ulp_messages` to retrieve them. 