### PR TITLE
Tool unify

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -19,7 +19,7 @@
 
 # ULP tools location.
 ULP = $(top_builddir)/tools/ulp
-ULP_POST = $(top_builddir)/tools/ulp_post
+ULP_POST = $(ULP) post
 ULP_PACKER = $(ULP) packer
 ULP_REVERSE = $(top_builddir)/tools/ulp_reverse
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -18,8 +18,9 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 # ULP tools location.
+ULP = $(top_builddir)/tools/ulp
 ULP_POST = $(top_builddir)/tools/ulp_post
-ULP_PACKER = $(top_builddir)/tools/ulp_packer
+ULP_PACKER = $(ULP) packer
 ULP_REVERSE = $(top_builddir)/tools/ulp_reverse
 
 # Build and link requirements for live-patchable (target) libraries.

--- a/Makefile.common
+++ b/Makefile.common
@@ -21,7 +21,7 @@
 ULP = $(top_builddir)/tools/ulp
 ULP_POST = $(ULP) post
 ULP_PACKER = $(ULP) packer
-ULP_REVERSE = $(top_builddir)/tools/ulp_reverse
+ULP_REVERSE = $(ULP) reverse
 
 # Build and link requirements for live-patchable (target) libraries.
 TARGET_CFLAGS = \
@@ -61,4 +61,4 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 	$(ULP_PACKER) $< -o $@
 
 %.rev: %.ulp
-	$(ULP_REVERSE) $< $@
+	$(ULP_REVERSE) $< -o $@

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -32,6 +32,8 @@
 #define ULP_PATH_LEN 256
 #define RED_ZONE_LEN 128
 
+#define ARRAY_LENGTH(v) (sizeof(v) / sizeof(*(v)))
+
 extern __thread int __ulp_pending;
 
 struct ulp_patching_state

--- a/man/ulp_check.1
+++ b/man/ulp_check.1
@@ -21,7 +21,7 @@
 .SH NAME
 ulp_check \- Apply a live patch
 .SH SYNOPSIS
-.B ulp_check
+.B ulp check
 [OPTION]...
 .BR -p pid
 .I file

--- a/man/ulp_packer.1
+++ b/man/ulp_packer.1
@@ -21,7 +21,7 @@
 .SH NAME
 ulp_packer \- Create live patch metadata
 .SH SYNOPSIS
-.B ulp_packer
+.B ulp packer
 [OPTION]...
 .I file
 .SH DESCRIPTION

--- a/man/ulp_post.1
+++ b/man/ulp_post.1
@@ -21,7 +21,7 @@
 .SH NAME
 ulp_post \- Post-process live patchable libraries
 .SH SYNOPSIS
-.B ulp_post
+.B ulp post
 .I file
 .SH DESCRIPTION
 .B ulp_post

--- a/man/ulp_trigger.1
+++ b/man/ulp_trigger.1
@@ -21,7 +21,7 @@
 .SH NAME
 ulp_trigger \- Apply a live patch
 .SH SYNOPSIS
-.B ulp_trigger
+.B ulp trigger
 [OPTION]...
 .BR -p pid
 .I file

--- a/tests/terminal.py
+++ b/tests/terminal.py
@@ -24,7 +24,7 @@ import subprocess
 import time
 
 import testsuite
-from testsuite import checker
+from testsuite import ulptool
 
 parent = testsuite.spawn('./terminal ./loop')
 
@@ -52,7 +52,8 @@ for i in range(32):
   # started by the testing framework. Rather, it has been forked from
   # its parent (terminal.c), thus, child.is_patch_applied and
   # child.livepatch cannot be used.
-  ret = subprocess.run([checker, '-q', '-p', pid, 'libblocked_livepatch1.ulp'])
+  ret = subprocess.run([ulptool, '-q', '-p', pid, "check",
+      'libblocked_livepatch1.ulp'])
   # The Check tool returns 0 when the given live patch has not been
   # applied, which is the expected output here. Anything else is treated
   # as a hard error (99), because detecting errors in the Check tool

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -38,7 +38,6 @@ testname = os.path.basename(testname[0])
 
 # Libpulp definitions
 builddir = os.getcwd()
-trigger = builddir + '/../tools/ulp_trigger'
 ulptool = builddir + '/../tools/ulp'
 
 # Wrapper around pexpect.spawn that automatically sets userspace livepatching
@@ -181,7 +180,7 @@ class spawn(pexpect.spawn):
     self.sanity(filename=filename)
 
     # Build command-line from arguments
-    command = [trigger, '-p', str(self.pid), filename]
+    command = [ulptool, "trigger", '-p', str(self.pid), filename]
     if verbose:
       command.append('-v')
     if quiet:

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -39,7 +39,6 @@ testname = os.path.basename(testname[0])
 # Libpulp definitions
 builddir = os.getcwd()
 trigger = builddir + '/../tools/ulp_trigger'
-checker = builddir + '/../tools/ulp_check'
 ulptool = builddir + '/../tools/ulp'
 
 # Wrapper around pexpect.spawn that automatically sets userspace livepatching
@@ -216,7 +215,7 @@ class spawn(pexpect.spawn):
     self.sanity(filename=filename)
 
     # Build command-line from arguments
-    command = [checker, '-p', str(self.pid), filename]
+    command = [ulptool, '-p', str(self.pid), "check",  filename]
     if verbose:
       command.append('-v')
     if quiet:

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -17,9 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-bin_PROGRAMS = \
-  ulp_reverse \
-  ulp
+bin_PROGRAMS = ulp
 
 noinst_HEADERS = \
   trigger.h \
@@ -31,7 +29,8 @@ noinst_HEADERS = \
   check.h \
   patches.h \
   dump.h \
-  post.h
+  post.h \
+  revert.h
 
 # Static library shared among the tools.
 
@@ -40,9 +39,17 @@ noinst_LTLIBRARIES = libcommon.la
 libcommon_la_SOURCES = introspection.c ptrace.c
 libcommon_la_LIBADD = -lelf -ldl $(LIBUNWIND_LIBS)
 
-ulp_reverse_SOURCES = revert.c
+ulp_SOURCES = \
+  ulp.c \
+  check.c \
+  patches.c \
+  dump.c \
+  packer.c \
+  md4.c \
+  trigger.c \
+  post.c \
+  revert.c
 
-ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c trigger.c post.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,11 +22,10 @@ bin_PROGRAMS = \
   ulp_reverse \
   ulp_dump \
   ulp_trigger \
-  ulp_check \
   ulp_post \
   ulp
 
-noinst_HEADERS = introspection.h ptrace.h packer.h md4.h
+noinst_HEADERS = arguments.h introspection.h ptrace.h packer.h md4.h check.h patches.h
 
 # Static library shared among the tools.
 
@@ -58,10 +57,7 @@ ulp_dump_LDADD = libcommon.la
 ulp_trigger_SOURCES = trigger.c
 ulp_trigger_LDADD = libcommon.la
 
-ulp_check_SOURCES = check.c
-ulp_check_LDADD = libcommon.la
-
-ulp_SOURCES = ulp.c
+ulp_SOURCES = ulp.c check.c patches.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -18,7 +18,6 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 bin_PROGRAMS = \
-  ulp_packer \
   ulp_reverse \
   ulp_trigger \
   ulp_post \
@@ -46,12 +45,6 @@ libcommon_la_LIBADD = -lelf -ldl $(LIBUNWIND_LIBS)
 ulp_post_SOURCES = post.c
 ulp_post_LDADD = -lelf
 
-# The packer and reverse tools create metadata files for live patches,
-# whereas the dump tool dumps their content in human-readable format.
-
-ulp_packer_SOURCES = packer.c md4.c
-ulp_packer_LDADD = libcommon.la -lelf
-
 ulp_reverse_SOURCES = revert.c
 
 # The trigger and check tools attach to live patchable processes to
@@ -61,7 +54,7 @@ ulp_reverse_SOURCES = revert.c
 ulp_trigger_SOURCES = trigger.c
 ulp_trigger_LDADD = libcommon.la
 
-ulp_SOURCES = ulp.c check.c patches.c dump.c
+ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -20,12 +20,19 @@
 bin_PROGRAMS = \
   ulp_packer \
   ulp_reverse \
-  ulp_dump \
   ulp_trigger \
   ulp_post \
   ulp
 
-noinst_HEADERS = arguments.h introspection.h ptrace.h packer.h md4.h check.h patches.h
+noinst_HEADERS = \
+  arguments.h \
+  introspection.h \
+  ptrace.h \
+  packer.h \
+  md4.h \
+  check.h \
+  patches.h \
+  dump.h
 
 # Static library shared among the tools.
 
@@ -47,9 +54,6 @@ ulp_packer_LDADD = libcommon.la -lelf
 
 ulp_reverse_SOURCES = revert.c
 
-ulp_dump_SOURCES = dump.c
-ulp_dump_LDADD = libcommon.la
-
 # The trigger and check tools attach to live patchable processes to
 # apply or check live patches, respectively. The ulp tool searches the
 # whole system for live patchable processes and report their state.
@@ -57,7 +61,7 @@ ulp_dump_LDADD = libcommon.la
 ulp_trigger_SOURCES = trigger.c
 ulp_trigger_LDADD = libcommon.la
 
-ulp_SOURCES = ulp.c check.c patches.c
+ulp_SOURCES = ulp.c check.c patches.c dump.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -19,7 +19,6 @@
 
 bin_PROGRAMS = \
   ulp_reverse \
-  ulp_post \
   ulp
 
 noinst_HEADERS = \
@@ -31,7 +30,8 @@ noinst_HEADERS = \
   md4.h \
   check.h \
   patches.h \
-  dump.h
+  dump.h \
+  post.h
 
 # Static library shared among the tools.
 
@@ -40,14 +40,9 @@ noinst_LTLIBRARIES = libcommon.la
 libcommon_la_SOURCES = introspection.c ptrace.c
 libcommon_la_LIBADD = -lelf -ldl $(LIBUNWIND_LIBS)
 
-# The post tool replaces one-byte nops with multi-byte nop instructions.
-
-ulp_post_SOURCES = post.c
-ulp_post_LDADD = -lelf
-
 ulp_reverse_SOURCES = revert.c
 
-ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c trigger.c
+ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c trigger.c post.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -19,11 +19,11 @@
 
 bin_PROGRAMS = \
   ulp_reverse \
-  ulp_trigger \
   ulp_post \
   ulp
 
 noinst_HEADERS = \
+  trigger.h \
   arguments.h \
   introspection.h \
   ptrace.h \
@@ -47,14 +47,7 @@ ulp_post_LDADD = -lelf
 
 ulp_reverse_SOURCES = revert.c
 
-# The trigger and check tools attach to live patchable processes to
-# apply or check live patches, respectively. The ulp tool searches the
-# whole system for live patchable processes and report their state.
-
-ulp_trigger_SOURCES = trigger.c
-ulp_trigger_LDADD = libcommon.la
-
-ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c
+ulp_SOURCES = ulp.c check.c patches.c dump.c packer.c md4.c trigger.c
 ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -1,0 +1,45 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARGUMENTS_H
+#define ARGUMENTS_H
+
+#include "config.h"
+
+#define ARGS_MAX 1
+
+typedef enum
+{
+  ULP_NONE,
+  ULP_PATCHES,
+  ULP_CHECK
+} command_t;
+
+struct arguments
+{
+  const char *args[ARGS_MAX];
+  pid_t pid;
+  command_t command;
+  int quiet;
+  int verbose;
+};
+
+#endif

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -32,11 +32,15 @@ typedef enum
   ULP_PATCHES,
   ULP_CHECK,
   ULP_DUMP,
+  ULP_PACKER,
 } command_t;
 
 struct arguments
 {
   const char *args[ARGS_MAX];
+  const char *livepatch;
+  const char *library;
+  const char *metadata;
   pid_t pid;
   command_t command;
   int quiet;

--- a/tools/check.c
+++ b/tools/check.c
@@ -19,7 +19,6 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <argp.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -30,109 +29,29 @@
 #include <string.h>
 #include <sys/user.h>
 
+#include "arguments.h"
+#include "check.h"
 #include "config.h"
 #include "introspection.h"
 #include "ulp_common.h"
 
-struct ulp_process target;
 extern struct ulp_metadata ulp;
 
-const char *argp_program_version = PACKAGE_STRING;
-
-struct arguments
-{
-  char *args[1];
-  pid_t pid;
-  int quiet;
-  int verbose;
-};
-
-static char doc[] =
-    "Determines if the live patch described in the METADATA file\n"
-    "is already applied to the process with PID.";
-
-static char args_doc[] = "-p PID METADATA";
-
-static struct argp_option options[] = {
-  { "pid", 'p', "PID", 0, "Check patch status in the process with PID", 0 },
-  { 0, 0, 0, 0, "Options:", 0 },
-  { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
-  { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
-  { 0 }
-};
-
-static error_t
-parser(int key, char *arg, struct argp_state *state)
-{
-  int path_length;
-  struct arguments *arguments;
-
-  arguments = state->input;
-
-  switch (key) {
-    case 'v':
-      arguments->verbose = 1;
-      break;
-    case 'q':
-      arguments->quiet = 1;
-      break;
-    case 'p':
-      arguments->pid = atoi(arg);
-      if (arguments->pid < 1)
-        argp_error(state,
-                   "The argument to '-p' must be greater than zero; got %d.",
-                   arguments->pid);
-      break;
-    case ARGP_KEY_ARG:
-      if (state->arg_num >= 1) {
-        argp_error(state, "Too many arguments.");
-      }
-      if (state->arg_num == 0) {
-        /* Path to live patch metadata file. */
-        path_length = strlen(arg);
-        if (path_length > ULP_PATH_LEN)
-          argp_error(state,
-                     "METADATA path must be shorter than %d bytes; got %d.",
-                     ULP_PATH_LEN, path_length);
-      }
-      arguments->args[state->arg_num] = arg;
-      break;
-    case ARGP_KEY_END:
-      if (state->arg_num < 1)
-        argp_error(state, "Too few arguments.");
-      if (arguments->quiet && arguments->verbose)
-        argp_error(state, "You must specify either '-v' or '-q' or none.");
-      break;
-    default:
-      return ARGP_ERR_UNKNOWN;
-  }
-
-  return 0;
-}
-
 int
-main(int argc, char **argv)
+run_check(struct arguments *arguments)
 {
-  char *livepatch;
+  const char *livepatch;
   int ret;
   int check;
   int result;
 
   struct ulp_process target;
 
-  struct argp argp = { options, parser, args_doc, doc, NULL, NULL, NULL };
-  struct arguments arguments;
-
-  arguments.pid = 0;
-  arguments.verbose = 0;
-  arguments.quiet = 0;
-  argp_parse(&argp, argc, argv, 0, 0, &arguments);
-
   /* Set the verbosity level in the common introspection infrastructure. */
-  ulp_verbose = arguments.verbose;
-  ulp_quiet = arguments.quiet;
+  ulp_verbose = arguments->verbose;
+  ulp_quiet = arguments->quiet;
 
-  livepatch = arguments.args[0];
+  livepatch = arguments->args[0];
 
   if (load_patch_info(livepatch)) {
     WARN("error parsing the metadata file (%s).", livepatch);
@@ -140,7 +59,7 @@ main(int argc, char **argv)
   }
 
   memset(&target, 0, sizeof(target));
-  target.pid = arguments.pid;
+  target.pid = arguments->pid;
   ret = initialize_data_structures(&target);
   if (ret) {
     WARN("error gathering target process information.");

--- a/tools/check.h
+++ b/tools/check.h
@@ -1,0 +1,29 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CHECK_H
+#define CHECK_H
+
+struct arguments;
+
+int run_check(struct arguments *);
+
+#endif

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include <sys/types.h>
 
 #include "arguments.h"
 #include "dump.h"

--- a/tools/dump.h
+++ b/tools/dump.h
@@ -19,29 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef DUMP_H
+#define DUMP_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
+int run_dump(struct arguments *);
 
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  pid_t pid;
-  command_t command;
-  int quiet;
-  int verbose;
-  int buildid_only;
-};
-
-#endif
+#endif /* DUMP_H */

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -844,7 +844,7 @@ restore_threads(struct ulp_process *process)
  * returns 0.
  */
 int
-load_patch_info(char *livepatch)
+load_patch_info(const char *livepatch)
 {
   uint32_t c;
   uint32_t i, j;

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -530,7 +530,7 @@ set_id_buffer(struct ulp_process *process, unsigned char *patch_id)
  * pre-condition to apply a new live patch. On success, returns 0.
  */
 int
-set_path_buffer(struct ulp_process *process, char *path)
+set_path_buffer(struct ulp_process *process, const char *path)
 {
   struct ulp_thread *thread;
   Elf64_Addr path_addr;
@@ -743,7 +743,7 @@ patch_applied(struct ulp_process *process, unsigned char *id, int *result)
  * called after successful thread hijacking.
  */
 int
-apply_patch(struct ulp_process *process, char *metadata)
+apply_patch(struct ulp_process *process, const char *metadata)
 {
   int ret;
   struct ulp_thread *thread;

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -143,7 +143,7 @@ int restore_threads(struct ulp_process *process);
 
 int read_global_universe(struct ulp_process *process);
 
-int load_patch_info(char *livepatch);
+int load_patch_info(const char *livepatch);
 
 int check_patch_sanity();
 

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -133,11 +133,11 @@ int hijack_threads(struct ulp_process *process);
 
 int set_id_buffer(struct ulp_process *process, unsigned char *patch_id);
 
-int set_path_buffer(struct ulp_process *process, char *path);
+int set_path_buffer(struct ulp_process *process, const char *path);
 
 int patch_applied(struct ulp_process *process, unsigned char *id, int *result);
 
-int apply_patch(struct ulp_process *process, char *metadata);
+int apply_patch(struct ulp_process *process, const char *metadata);
 
 int restore_threads(struct ulp_process *process);
 

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -19,37 +19,44 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef PACKER_H
+#define PACKER_H
+
 #include <gelf.h>
 #include <stdio.h>
 #include <unistd.h>
 
 #include "ulp_common.h"
 
-void usage(char *name);
+struct arguments;
 
 void free_metadata(struct ulp_metadata *ulp);
 
 void unload_elf(Elf **elf, int *fd);
 
-Elf *load_elf(char *obj, int *fd);
+Elf *load_elf(const char *obj, int *fd);
 
 Elf_Scn *get_dynsym(Elf *elf);
 
 Elf_Scn *get_build_id_note(Elf *elf);
 
-int get_ulp_elf_metadata(char *filename, struct ulp_object *obj);
+int get_ulp_elf_metadata(const char *filename, struct ulp_object *obj);
 
 int get_object_metadata(Elf *elf, struct ulp_object *obj);
 
 int get_elf_tgt_addrs(Elf *elf, struct ulp_object *obj, Elf_Scn *st);
 
-int create_patch_metadata_file(struct ulp_metadata *ulp, char *filename);
+int create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename);
 
 int add_dependency(struct ulp_metadata *ulp, struct ulp_dependency *dep,
-                   char *filename);
+                   const char *filename);
 
-int parse_description(char *filename, struct ulp_metadata *ulp);
+int parse_description(const char *filename, struct ulp_metadata *ulp);
 
 int get_build_id(Elf_Scn *s, struct ulp_object *obj);
 
-void *get_symbol_addr(Elf *elf, Elf_Scn *s, char *search);
+void *get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search);
+
+int run_packer(struct arguments *);
+
+#endif /* PACKER_H */

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -1,0 +1,210 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <argp.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "arguments.h"
+#include "config.h"
+#include "introspection.h"
+#include "patches.h"
+
+/* Returns 0 if libpulp.so has been loaded by the process with memory map
+ * (/proc/<pid>/maps) opened in MAP. Otherwise, returns 1.
+ */
+int
+libpulp_loaded(FILE *map)
+{
+  int retcode = 0;
+
+  char *line = NULL;
+  size_t len = 0;
+
+  /* Read all lines of MAP and look for the 'libpulp.so' substring. */
+  rewind(map);
+  while (getline(&line, &len, map) != -1) {
+    if (strstr(line, "libpulp.so")) {
+      retcode = 1;
+      break;
+    }
+  }
+
+  /* Free structures allocated by getline() and return. */
+  free(line);
+  return retcode;
+}
+
+/* Attaches to PROCESS multiple times and collect information about its
+ * applied live patches and loaded libraries. Returns 0 on
+ * success; 1 if process information was not properly parsed; and -1 if
+ * process hijacking went wrong, which also means that PROCESS was
+ * probably put into an inconsistent state and should be killed.
+ */
+int
+get_process_universes(struct ulp_process *process)
+{
+  if (initialize_data_structures(process))
+    return 1;
+
+  if (hijack_threads(process))
+    return -1;
+
+  read_global_universe(process);
+
+  if (restore_threads(process))
+    return -1;
+
+  return 0;
+}
+
+/* Inserts a new process structure into LIST if the process identified
+ * by PID is live-patchable.
+ */
+void
+insert_target_process(int pid, struct ulp_process **list)
+{
+  char mapname[PATH_MAX];
+  FILE *map;
+
+  struct ulp_process *new = NULL;
+
+  snprintf(mapname, PATH_MAX, "/proc/%d/maps", pid);
+  if ((map = fopen(mapname, "r")) == NULL) {
+    /* EACESS error happens when the tool is executed by a regular user.
+       This is not a hard error. */
+    if (errno != EACCES)
+      perror("Unable to open memory map for process");
+    return;
+  }
+
+  /* If the process identified by PID is live patchable, add to LIST. */
+  if (libpulp_loaded(map)) {
+    new = malloc(sizeof(struct ulp_process));
+    memset(new, 0, sizeof(struct ulp_process));
+
+    new->pid = pid;
+    if (get_process_universes(new)) {
+      printf("Failed to parsed data for live-patchable process %d... "
+             "Skipping.\n",
+             pid);
+    }
+    else {
+      new->next = *list;
+      *list = new;
+    }
+  }
+
+  fclose(map);
+}
+
+/* Iterates over /proc and builds a list of live-patchable processes.
+ * Returns said list.
+ */
+struct ulp_process *
+build_process_list(void)
+{
+  long int pid;
+
+  DIR *slashproc;
+  struct dirent *subdir;
+
+  struct ulp_process *list = NULL;
+
+  /* Build a list of all processes that have libpulp.so loaded. */
+  slashproc = opendir("/proc");
+  if (slashproc == NULL) {
+    perror("Is /proc mounted?");
+    return NULL;
+  }
+
+  while ((subdir = readdir(slashproc))) {
+    /* Skip non-numeric directories in /proc. */
+    if ((pid = strtol(subdir->d_name, NULL, 10)) == 0)
+      continue;
+    /* Add live patchable process. */
+    insert_target_process(pid, &list);
+  }
+  closedir(slashproc);
+
+  return list;
+}
+
+/* Prints all the info collected about the processes in PROCESS_LIST. */
+void
+print_process_list(struct ulp_process *process_list)
+{
+  struct ulp_process *process_item;
+  struct ulp_dynobj *object_item;
+
+  process_item = process_list;
+  while (process_item) {
+
+    printf("PID: %d\n", process_item->pid);
+
+    printf("  Global universe: %ld\n", process_item->global_universe);
+
+    printf("  Live patches:\n");
+    object_item = process_item->dynobj_patches;
+    if (!object_item)
+      printf("    (none)\n");
+    while (object_item) {
+      printf("    %s\n", object_item->filename);
+      object_item = object_item->next;
+    }
+
+    printf("  Loaded libraries:\n");
+    object_item = process_item->dynobj_targets;
+    if (!object_item)
+      printf("    (none)\n");
+    while (object_item) {
+      printf("    in %s:\n", object_item->filename);
+      object_item = object_item->next;
+    }
+    process_item = process_item->next;
+    printf("\n");
+  }
+}
+
+int
+run_patches(struct arguments *arguments)
+{
+  struct ulp_process *process_list;
+
+  /*
+   * If the PID argument has not been provided, check all live patchable
+   * processes; otherwise, just the request process.
+   */
+  if (arguments->pid == 0)
+    process_list = build_process_list();
+  else {
+    process_list = NULL;
+    insert_target_process(arguments->pid, &process_list);
+  }
+
+  print_process_list(process_list);
+
+  return 0;
+}

--- a/tools/patches.h
+++ b/tools/patches.h
@@ -1,0 +1,29 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PATCHES_H
+#define PATCHES_H
+
+struct arguments;
+
+int run_patches(struct arguments *);
+
+#endif

--- a/tools/post.h
+++ b/tools/post.h
@@ -1,7 +1,7 @@
 /*
  *  libpulp - User-space Livepatching Library
  *
- *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
  *
  *  This file is part of libpulp.
  *
@@ -19,39 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef POST_H
+#define POST_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
+int run_post(struct arguments *);
 
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  pid_t pid;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid_only;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
-
-#endif
+#endif /* POST_H */

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -68,7 +68,7 @@ write_byte(char byte, int pid, Elf64_Addr addr)
  * Returns 0 if the operation succeeds; 1 otherwise.
  */
 int
-write_string(char *buffer, int pid, Elf64_Addr addr, int length)
+write_string(const char *buffer, int pid, Elf64_Addr addr, int length)
 {
   int i;
 

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -32,7 +32,7 @@
 /* Memory read/write helper functions */
 int write_byte(char byte, int pid, Elf64_Addr addr);
 
-int write_string(char *buffer, int pid, Elf64_Addr addr, int length);
+int write_string(const char *buffer, int pid, Elf64_Addr addr, int length);
 
 int read_byte(char *byte, int pid, Elf64_Addr addr);
 

--- a/tools/revert.c
+++ b/tools/revert.c
@@ -30,7 +30,7 @@
 
 #include "packer.h"
 
-void
+static void
 usage(char *name)
 {
   fprintf(stderr, "Usage: %s <ulp metadata file> [output filename]\n", name);

--- a/tools/revert.c
+++ b/tools/revert.c
@@ -28,16 +28,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "arguments.h"
 #include "packer.h"
+#include "revert.h"
 
-static void
-usage(char *name)
-{
-  fprintf(stderr, "Usage: %s <ulp metadata file> [output filename]\n", name);
-}
-
-int
-write_reverse_patch(struct ulp_metadata *ulp, char *filename)
+static int
+write_reverse_patch(struct ulp_metadata *ulp, const char *filename)
 {
   FILE *file;
   char type = 2;
@@ -85,8 +81,8 @@ write_reverse_patch(struct ulp_metadata *ulp, char *filename)
   return 1;
 }
 
-struct ulp_metadata *
-parse_metadata(char *filename, struct ulp_metadata *ulp)
+static struct ulp_metadata *
+parse_metadata(const char *filename, struct ulp_metadata *ulp)
 {
   FILE *file;
   struct ulp_object *obj;
@@ -172,21 +168,14 @@ parse_metadata(char *filename, struct ulp_metadata *ulp)
 }
 
 int
-main(int argc, char **argv)
+run_reverse(struct arguments *arguments)
 {
   struct ulp_metadata ulp;
-  char *filename = NULL;
+  /* .metadata is passed in .o from packer.  */
+  const char *filename = arguments->metadata;
+  const char *metadata = arguments->args[0];
 
-  if (argc < 2) {
-    usage(argv[0]);
-    return 1;
-  }
-
-  if (argc > 2) {
-    filename = strndup(argv[2], NAME_MAX);
-  }
-
-  if (!parse_metadata(argv[1], &ulp)) {
+  if (!parse_metadata(metadata, &ulp)) {
     WARN("Error parsing ulp metadata.\n");
     return 1;
   }

--- a/tools/revert.h
+++ b/tools/revert.h
@@ -19,40 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef REVERT_H
+#define REVERT_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
+int run_reverse(struct arguments *);
 
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-  ULP_REVERSE,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  pid_t pid;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid_only;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
-
-#endif
+#endif /* REVERT_H */

--- a/tools/trigger.h
+++ b/tools/trigger.h
@@ -19,38 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef TRIGGER_H
+#define TRIGGER_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
+int run_trigger(struct arguments *);
 
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  pid_t pid;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid_only;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
-
-#endif
+#endif /* TRIGGER_H */

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -34,6 +34,7 @@
 #include "introspection.h"
 #include "packer.h"
 #include "patches.h"
+#include "post.h"
 #include "trigger.h"
 
 static error_t parser(int, char *, struct argp_state *);
@@ -59,7 +60,8 @@ static const char doc[] =
 "   packer                    Creates a livepatch METADATA file based on a\n"
 "                             live patch description on ARG1.\n"
 "   trigger                   Applies the live patch in ARG1 to the process\n"
-"                             with PID\n";
+"                             with PID\n"
+"   post                      Post process patch container (.so file) in ARG1.\n";
 /* clang-format on */
 
 static struct argp_option options[] = {
@@ -107,7 +109,7 @@ command_from_string(const char *str)
   static const struct entry entries[] = {
     { "patches", ULP_PATCHES }, { "check", ULP_CHECK },
     { "dump", ULP_DUMP },       { "packer", ULP_PACKER },
-    { "trigger", ULP_TRIGGER },
+    { "trigger", ULP_TRIGGER }, { "post", ULP_POST },
   };
 
   size_t i;
@@ -149,7 +151,8 @@ handle_end_of_arguments(const struct argp_state *state)
         argp_error(state, "Too few arguments.");
       break;
 
-    /* Currently, ULP_TRIGGER and DUMP does the same checks.  */
+    /* Currently, ULP_TRIGGER, DUMP & POST does the same checks.  */
+    case ULP_POST:
     case ULP_TRIGGER:
     case ULP_DUMP:
       if (state->arg_num < 2)
@@ -263,6 +266,10 @@ main(int argc, char **argv)
 
     case ULP_TRIGGER:
       ret = run_trigger(&arguments);
+      break;
+
+    case ULP_POST:
+      ret = run_post(&arguments);
       break;
   }
 


### PR DESCRIPTION
This commit unify all ulp tools into one.

Syntax:
```
ulp COMMAND ARG1
```
for instance, old `ulp_trigger` is now `ulp trigger`.