### PR TITLE
Look for libpulp symbols in remote process

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -24,7 +24,8 @@ libpulp_la_DEPENDENCIES= libpulp.versions
 libpulp_la_LDFLAGS = \
   -ldl \
   -Wl,--version-script=$(srcdir)/libpulp.versions \
-  $(AM_LDFLAGS)
+  -Wl,--hash-style=sysv \ # Ubuntu seems to default to gnu, so be clear we ...
+  $(AM_LDFLAGS) # ... want old style hash sections, else DT_HASH is empty.
 
 AM_CFLAGS += -I$(top_srcdir)/include
 

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -19,6 +19,12 @@
     dladdr;
     dladdr1;
     dlinfo;
+    __ulp_trigger;
+    __ulp_path_buffer;
+    __ulp_check_patched;
+    __ulp_state;
+    __ulp_get_global_universe;
+    __ulp_msg_queue;
   local:
     *;
 };

--- a/lib/ulp_interface.S
+++ b/lib/ulp_interface.S
@@ -37,18 +37,21 @@
  * executed, without side-effects).
  */
 
+.global __ulp_trigger
 __ulp_trigger:
     nop
     nop
     call    __ulp_apply_patch@PLT
     int3
 
+.global __ulp_check_patched
 __ulp_check_patched:
     nop
     nop
     call   __ulp_check_applied_patch@PLT
     int3
 
+.global __ulp_get_global_universe
 __ulp_get_global_universe:
     nop
     nop

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -94,12 +94,14 @@ struct ulp_dynobj
   char *filename;
   struct link_map link_map;
 
+  /* FIXME: only libpulp objects should have those symbols.  */
   Elf64_Addr trigger;
   Elf64_Addr check;
   Elf64_Addr path_buffer;
   Elf64_Addr state;
   Elf64_Addr global;
   Elf64_Addr msg_queue;
+  /* end FIXME.  */
 
   struct thread_state *thread_states;
 
@@ -117,7 +119,11 @@ struct ulp_addresses
 
 int dig_main_link_map(struct ulp_process *process);
 
-Elf64_Addr get_loaded_symbol_addr(struct ulp_dynobj *obj, char *sym);
+Elf64_Addr get_loaded_symbol_addr_on_disk(struct ulp_dynobj *obj,
+                                          const char *sym);
+
+Elf64_Addr get_loaded_symbol_addr(struct ulp_dynobj *obj, int pid,
+                                  const char *sym);
 
 int dig_load_bias(struct ulp_process *process);
 


### PR DESCRIPTION
Previously, libpulp find symbols address by reading the ELF file of
target process/library and used the offset of the symbol there to
compute its address. Now, look at the remote process of these symbols.
This has the advantage of not having to rely on the process binary
in disk, that could be modified in the meanwhile of loading the
process and applying the patch.

However, this comes with a cost: ptracing the remote process seems
to be slower than reading the in disk information. We reduced this
overhead avoiding looking into libraries which name does not contain
"libpulp". However, there are still margin for optimizations here.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>