### PR TITLE
Shrink prologue size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,8 +153,8 @@ AC_SUBST([PAGE_SIZE], [$($GETCONF PAGE_SIZE)]))
 # before the entry point, and the remaining nops after it. At running time,
 # whenever a live patch is applied, libpulp replaces the remaining nops with
 # instructions that redirect execution to the universe handling routines.
-AC_SUBST([ULP_NOPS_LEN], [24])
-AC_SUBST([PRE_NOPS_LEN], [22])
+AC_SUBST([ULP_NOPS_LEN], [16])
+AC_SUBST([PRE_NOPS_LEN], [14])
 AC_DEFINE_UNQUOTED([ULP_NOPS_LEN], [$ULP_NOPS_LEN],
 [Total number of padding nops])
 AC_DEFINE_UNQUOTED([PRE_NOPS_LEN], [$PRE_NOPS_LEN],

--- a/include/ulp.h
+++ b/include/ulp.h
@@ -115,8 +115,7 @@ int check_build_id(struct ulp_metadata *ulp);
 
 void ulp_patch_addr_absolute(void *old_faddr, void *new_faddr);
 
-int ulp_patch_addr(void *old_faddr, void *new_faddr, unsigned int index,
-                   int enable);
+int ulp_patch_addr(void *old_faddr, void *new_faddr, int enable);
 
 struct ulp_applied_patch *ulp_get_applied_patch(unsigned char *id);
 


### PR DESCRIPTION
Since commit 19e37546ebed6d10224b1e73fe74aa93b1949df8, prologues behaved
as:
```
    function prologue:
        push    %rdi           <-- Unused!
        movq    $index, %rdi   <-- Unused!
  ┌───> jmp     0x0(%rip)
  │     <data>  <target function>
  │ function entry:
  └──── jmp     <function prologue>
```
The first two instructions in the prologue became purposeless, once
they had no semantic behaviour in the program. This commit removes
those two unused instructions in the prologue and reduce its size from
24 bytes to 16 bytes.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>