### PR TITLE
Print build id of libraries linked against target process

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -29,7 +29,10 @@ TARGET_CFLAGS = \
   -fpatchable-function-entry=$(ULP_NOPS_LEN),$(PRE_NOPS_LEN) \
   -fno-inline \
   $(AM_CFLAGS)
-TARGET_LDFLAGS = --build-id $(AM_LDFLAGS)
+TARGET_LDFLAGS = \
+  --build-id \
+  -Wl,--hash-style=sysv \ # Ubuntu seems to default to gnu, so be clear we ...
+  $(AM_LDFLAGS) # ... want old style hash sections, else DT_HASH is empty.
 
 # In libtool, convenience libraries are not installed, so they do not
 # need -rpath, which causes them to be statically linked.  However,

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -50,7 +50,7 @@ struct arguments
   int retries;
   int quiet;
   int verbose;
-  int buildid_only;
+  int buildid;
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   int check_stack;
 #endif

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -88,6 +88,6 @@ run_dump(struct arguments *arguments)
     WARN("error parsing the metadata file (%s).", arguments->args[0]);
     return 1;
   }
-  dump_metadata(&ulp, arguments->buildid_only);
+  dump_metadata(&ulp, arguments->buildid);
   return 0;
 }

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -91,10 +91,32 @@ struct thread_state
   struct thread_state *next;
 };
 
+/** Length of build id, in bytes.  */
+#define BUILDID_LEN 20
+
+/** Represents a dynamic object, such as dynamic libraries (.so) or the
+ *  executable itself.
+ */
 struct ulp_dynobj
 {
+  /** Name of the library. Empty string in case of the executable itself.  */
   char *filename;
+
+  /* Link map, as in _r_debug symbol loaded by the linker.  */
   struct link_map link_map;
+
+  /** Address of dynstr section of current library in the target process.  */
+  Elf64_Addr dynstr_addr;
+
+  /** Address of dynsym section of current library in the target process.  */
+  Elf64_Addr dynsym_addr;
+
+  /** Number of symbols in the dynsym section of current library in the target
+   * process.  */
+  int num_symbols;
+
+  /** Build id of current library loaded in the target process.  */
+  unsigned char build_id[BUILDID_LEN];
 
   /* FIXME: only libpulp objects should have those symbols.  */
   Elf64_Addr trigger;
@@ -107,6 +129,7 @@ struct ulp_dynobj
 
   struct thread_state *thread_states;
 
+  /** Next dynobj in the dynobj chain (linked list).  */
   struct ulp_dynobj *next;
 };
 

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -75,8 +75,8 @@ static struct argp_option options[] = {
   { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
   { 0, 0, 0, 0, "patches & check commands only:", 0 },
   { "pid", 'p', "PID", 0, "Target process with PID", 0 },
-  { 0, 0, 0, 0, "dump command only:", 0 },
-  { "buildid", 'b', 0, 0, "Only print the build id (dump only.)", 0 },
+  { 0, 0, 0, 0, "dump & patches command only:", 0 },
+  { "buildid", 'b', 0, 0, "Print the build id", 0 },
   { 0, 0, 0, 0, "trigger command only:", 0 },
   { "retries", 'r', "N", 0, "Retry N times if process busy", 0 },
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
@@ -198,7 +198,7 @@ parser(int key, char *arg, struct argp_state *state)
       arguments->pid = atoi(arg);
       break;
     case 'b':
-      arguments->buildid_only = 1;
+      arguments->buildid = 1;
       break;
     case 'o':
       arguments->metadata = arg;


### PR DESCRIPTION
Now, the `patches` command can print the build id of each library
linked agaist the target process using:
```
$ ulp patches -p $(pid) -b
```
Output example:
```
    PID: 3092
      Global universe: 0
      Live patches:
        (none)
      Loaded libraries:
        in /lib64/ld-linux-x86-64.so.2 (3ad62ce668e64d1f7dddd9386f90129c57cc265e):
        in /lib64/libdl.so.2 (338aa4d16c98dda7af170cc8e2b59d259bd5d4f4):
        in /lib64/libc.so.6 (c3c4f482259e3974d74db18e1cbb52bec0f5094a):
        in libparameters.so.0 (8eadb55ed15e43a6c2ae7f6098179bceb3abda2b):
        in ../lib/.libs/libpulp.so (6e0710119ae02bd80356c2d5cf02d2f31f4025f7):
        in linux-vdso.so.1 (0000000000000000000000000000000000000000):
```
Retrieving the build id of a certain library is straightforward using
grep. For example:
```
$ ulp patches -b -p $(pid) | grep libdl.so | grep -oEi '([0-9a-f]){40}'
```
returns `338aa4d16c98dda7af170cc8e2b59d259bd5d4f4`

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>