### PR TITLE
Add support for relative paths in target library

### DIFF
--- a/include/msg_queue.h
+++ b/include/msg_queue.h
@@ -22,10 +22,10 @@
 #ifndef MSGQ_H
 #define MSGQ_H
 
-/* Define a 2Mb buffer for holding the messages.  */
+/** Define a 2Mb buffer for holding the messages.  */
 #define MSGQ_BUFFER_MAX (2 * 1024 * 1024)
 
-/* This is the circular message queue datastructure.
+/** This is the circular message queue datastructure.
  *
  * It works on a fixed-size buffer and operates maintaining three variables:
  *
@@ -60,19 +60,28 @@
  */
 struct msg_queue
 {
-  char buffer[MSGQ_BUFFER_MAX]; /* Buffer holding the messages.  */
-  int top;      /* Position pointing to free memory that can be written to.  */
-  int bottom;   /* Position pointing to the oldest message still in buffer.  */
-  int distance; /* Distance betweem top and bottom.  Should not be greater than
-                   MSGQ_BUFFER_MAX.  */
+  /** Buffer holding the messages.  */
+  char buffer[MSGQ_BUFFER_MAX];
+
+  /** Position pointing to free memory that can be written to.  */
+  int top;
+
+  /** Position pointing to the oldest message still in buffer.  */
+  int bottom;
+
+  /** Distance betweem top and bottom. Should not be greater than
+   * MSGQ_BUFFER_MAX.  */
+  int distance;
 };
 
 extern struct msg_queue __ulp_msg_queue;
 
 void msgq_push(const char *format, ...);
 
-/* Warn message using the message queue.  */
-
+/** Send a warning message to the message queue.  */
 #define MSGQ_WARN(fmt, ...) msgq_push("ulp: " fmt "\n", ##__VA_ARGS__)
+
+/** Send a debug message to the message queue, if debugging is enabled.  */
+#define MSGQ_DEBUG(fmt, ...) msgq_push("ulp: " fmt "\n", ##__VA_ARGS__)
 
 #endif /* MSGQ_H */

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -340,6 +340,8 @@ parse_metadata(struct ulp_metadata *ulp)
     return 0;
   }
 
+  MSGQ_DEBUG("Opened metadata file: %s", __ulp_path_buffer);
+
   ulp->objs = NULL;
 
 #define READ(from, to, count) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -165,6 +165,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libhundreds_bsymbolic_livepatch1.la \
                      libparameters_livepatch1.la \
                      libparameters_livepatch2.la \
+                     libparameters_livepatch3.la \
                      librecursion_livepatch1.la \
                      libblocked_livepatch1.la \
                      libpagecross_livepatch1.la \
@@ -199,6 +200,9 @@ libparameters_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libparameters_livepatch2_la_SOURCES = libparameters_livepatch2.c
 libparameters_livepatch2_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+libparameters_livepatch3_la_SOURCES = libparameters_livepatch3.c
+libparameters_livepatch3_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 librecursion_livepatch1_la_SOURCES = librecursion_livepatch1.c
 librecursion_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -249,6 +253,9 @@ METADATA = \
   libparameters_livepatch2.dsc \
   libparameters_livepatch2.ulp \
   libparameters_livepatch2.rev \
+  libparameters_livepatch3.dsc \
+  libparameters_livepatch3.ulp \
+  libparameters_livepatch3.rev \
   librecursion_livepatch1.dsc \
   librecursion_livepatch1.ulp \
   librecursion_livepatch1.rev \
@@ -281,6 +288,7 @@ EXTRA_DIST = \
   libhundreds_bsymbolic_livepatch1.in \
   libparameters_livepatch1.in \
   libparameters_livepatch2.in \
+  libparameters_livepatch3.in \
   librecursion_livepatch1.in \
   libblocked_livepatch1.in \
   libpagecross_livepatch1.in \
@@ -421,7 +429,8 @@ TESTS = \
   missing_function.py \
   access.py \
   buildid.py \
-  libpulp_messages.py
+  libpulp_messages.py \
+  relative_path.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/libparameters_livepatch3.c
+++ b/tests/libparameters_livepatch3.c
@@ -1,0 +1,36 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+void
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+{
+  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+}
+
+void
+new_float_params(float a, float b, float c, float d, float e, float f, float g,
+                 float h, float i, float j)
+{
+  printf("%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f\n", j, i, h, g, f,
+         e, d, c, b, a);
+}

--- a/tests/libparameters_livepatch3.in
+++ b/tests/libparameters_livepatch3.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libparameters_livepatch1.so
+@.libs/libparameters.so.0
+int_params:new_int_params
+float_params:new_float_params

--- a/tests/relative_path.py
+++ b/tests/relative_path.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('parameters')
+
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.livepatch('libparameters_livepatch3.ulp')
+
+child.sendline('')
+child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
+             reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
Now the metadata format accepts relative paths when specifying the path
to the target library. The way it works is by comparing both library
base name and build id to match the library to patch, instead of relying
on the full path to it.

Example:
```
__ABS_BUILDDIR__/.libs/libparameters_livepatch1.so
@.libs/libparameters.so.0
int_params:new_int_params
float_params:new_float_params
```
Notice that the line starting with @ do not require to be the full path
to target library anymore.

Signed-off-by: Giuliano Belinassi <giulianob@gbelinassi.udp.ovpn1.nue.suse.de>