### PR TITLE
Enable support for address sanitizer in ulp tools

### DIFF
--- a/.github/workflows/test-suite-sanitizers.yml
+++ b/.github/workflows/test-suite-sanitizers.yml
@@ -1,0 +1,33 @@
+name: Test Suite with Sanitizers
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: sudo apt install autoconf-archive libelf-dev python3-pexpect python3-psutil libunwind-dev
+    - name: permissions
+      run: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: ./configure --enable-stack-check --enable-sanitizers
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+      id: check
+    - name: diagnostics
+      if: failure () && steps.check.outcome == 'failure'
+      run: cat tests/test-suite.log
+    - name: make distcheck
+      run: make distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,21 @@ AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign subdir-objects])
 # supposed to be dynamically linked into applications.
 LT_INIT([shared disable-static])
 
+# Enable sanitizers on ulp tools
+AC_ARG_ENABLE(sanitizers,
+AS_HELP_STRING([--enable-sanitizers],
+[compile ulp tools with address and undefined-behaviour sanitizer [default=no]]),
+[enable_sanitizers=yes]
+[AC_SUBST([UBSAN_OPTIONS], ["print_stack_trace=1 detect_stack_use_after_return=1"])],
+[enable_sanitizesr=no; break])
+
+AM_CONDITIONAL([ENABLE_ADDRSAN], [test "x$enable_sanitizers" == "xyes"])
+
+# We need to disable optimizations if libsanitizer is enabled, else we
+# lose interesting informations about the leaks/errors.
+AS_IF([test "x$enable_sanitizers" == "xyes"],
+      [CFLAGS="-O0 -g"], [])
+
 AC_PROG_CC
 AC_PROG_CXX
 AM_PROG_AS
@@ -89,7 +104,6 @@ AC_SUBST([AM_CFLAGS], ["-Wall -Wextra -Werror"])
 AC_SUBST([AM_CCASFLAGS], ["-Wa,--fatal-warnings"])
 
 # Use the glibc versions installed on path
-# "-Wl,--dynamic-linker=$enableval/lib64/ld-linux-x86-64.so.2 -Wl,--rpath=$enableval/lib64/"
 AC_ARG_WITH([glibc],
 AC_HELP_STRING([--with-glibc=GLIBC_PATH],
 [Use the glibc installed on GLIBC_PATH, where the .so file is present]),

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -55,3 +55,9 @@ ulp_LDADD = libcommon.la
 
 # Ensure access to the include directory
 AM_CFLAGS += -I$(abs_top_srcdir)/include
+
+if ENABLE_ADDRSAN
+# Add address sanitizer
+AM_CFLAGS += -fsanitize=address,undefined
+AM_LDFLAGS += -fsanitize=address,undefined
+endif

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -142,6 +142,8 @@ struct ulp_addresses
   Elf64_Addr global;
 };
 
+void release_ulp_process(struct ulp_process *);
+
 int dig_main_link_map(struct ulp_process *process);
 
 Elf64_Addr get_loaded_symbol_addr_on_disk(struct ulp_dynobj *obj,

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -124,26 +124,29 @@ print_message_buffer(const struct ulp_process *p, bool debug)
 int
 run_messages(struct arguments *arguments)
 {
-  int ret;
-  struct ulp_process target;
+  int ret = 0;
+  struct ulp_process *target = calloc(1, sizeof(struct ulp_process));
 
   /* Set the verbosity level in the common introspection infrastructure. */
   ulp_verbose = arguments->verbose;
   ulp_quiet = arguments->quiet;
 
-  memset(&target, 0, sizeof(target));
-  target.pid = arguments->pid;
-  ret = initialize_data_structures(&target);
+  target->pid = arguments->pid;
+  ret = initialize_data_structures(target);
   if (ret) {
     WARN("error gathering target process information.");
-    return 1;
+    ret = 1;
+    goto ulp_process_clean;
   }
 
-  ret = print_message_buffer(&target, false);
+  ret = print_message_buffer(target, false);
   if (ret > 0) {
     WARN("message queue reading failed.");
-    return 1;
+    ret = 1;
+    goto ulp_process_clean;
   }
 
-  return 0;
+ulp_process_clean:
+  release_ulp_process(target);
+  return ret;
 }

--- a/tools/revert.c
+++ b/tools/revert.c
@@ -170,7 +170,7 @@ parse_metadata(const char *filename, struct ulp_metadata *ulp)
 int
 run_reverse(struct arguments *arguments)
 {
-  struct ulp_metadata ulp;
+  struct ulp_metadata ulp = { 0 };
   /* .metadata is passed in .o from packer.  */
   const char *filename = arguments->metadata;
   const char *metadata = arguments->args[0];
@@ -184,5 +184,6 @@ run_reverse(struct arguments *arguments)
     WARN("Error gerenating reverse live patch.\n");
     return 2;
   }
+  free_metadata(&ulp);
   return 0;
 }


### PR DESCRIPTION
This PR enables and fixes all address sanitizer problems in ulp tools.

Address sanitizer can be enabled with `--enable-address-sanitizer` in configure.