### PR TITLE
Add ulp_apply tool for packaging

### DIFF
--- a/tools/ulp_apply
+++ b/tools/ulp_apply
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Usage: ./ulp_apply "/usr/lib64/libcrypto.so.1.1" "/usr/lib64/openssl-1_1-livepatches/libcrypto_livepatch1.ulp"
+
+PULP_LIB="/usr/lib64/libpulp.so.0.0.0"
+UPDATE_LIB=$1
+
+# For each process
+#  Check if lib we want to update is loaded and that libpulp is loaded
+#  Todo: check for applied patch and revert - this is being done inside ulp trigger
+#  Call ulp_buildid to get NT_GNU_BUILDID
+#  Check BUILD_ID against each .ulp file, if found apply the live patch.
+
+for d in /proc/[0-9]*/ ; do
+    PID=${d:6:-1}
+    NEEDS_PATCH=$(find "$d/maps" -type f  -exec grep -q "$UPDATE_LIB" {} \; -exec grep -l "$PULP_LIB" {} \;)
+    if [[ $NEEDS_PATCH ]]; then
+      BUILD_ID=$(ulp patches -b -p $PID | grep /lib64/libc.so.6 | grep -oEi '([0-9a-f]){40}')
+
+      #TODO Error exit if BUILD_ID is empty
+      for ulp_file in /usr/lib64/*/*.ulp ; do
+	FILE_BUILD_ID=$(ulp dump -b $ulp_file | sed 's/ //g')
+    	if [[ "$BUILD_ID" == "$FILE_BUILD_ID" ]] ; then
+          echo "Updating $PID"
+	  ulp trigger -p $PID $ulp_file
+	fi	
+      done
+    fi
+done
+
+#TODO Warn if found nothing to upgrade.


### PR DESCRIPTION
This is a script that we will call from rpm post package install
to update any running processes with the new live patches.

While it could still use things such as better error reporting at
this point it is functional. The name and the final location for
the script are open to change (currently its not installed)