### PR TITLE
Add `--revert-all` for trigger

### DIFF
--- a/include/ulp.h
+++ b/include/ulp.h
@@ -32,6 +32,7 @@
 struct ulp_applied_patch
 {
   unsigned char patch_id[32];
+  const char *lib_name;
   struct ulp_applied_unit *units;
   struct ulp_applied_patch *next;
   struct ulp_dependency *deps;
@@ -95,7 +96,7 @@ void *load_so(char *obj);
 
 int load_patch();
 
-int ulp_can_revert_patch(struct ulp_metadata *ulp);
+int ulp_can_revert_patch(const unsigned char *id);
 
 int is_object_consistent(struct ulp_object *obj);
 
@@ -117,7 +118,7 @@ void ulp_patch_addr_absolute(void *old_faddr, void *new_faddr);
 
 int ulp_patch_addr(void *old_faddr, void *new_faddr, int enable);
 
-struct ulp_applied_patch *ulp_get_applied_patch(unsigned char *id);
+struct ulp_applied_patch *ulp_get_applied_patch(const unsigned char *id);
 
 int ulp_revert_patch(unsigned char *id);
 

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -19,6 +19,7 @@
     dladdr;
     dladdr1;
     dlinfo;
+    __ulp_revert_all;
     __ulp_trigger;
     __ulp_path_buffer;
     __ulp_check_patched;

--- a/lib/ulp_interface.S
+++ b/lib/ulp_interface.S
@@ -37,6 +37,13 @@
  * executed, without side-effects).
  */
 
+.global __ulp_revert_all
+__ulp_revert_all:
+    nop
+    nop
+    call    __ulp_revert_patches_from_lib@PLT
+    int3
+
 .global __ulp_trigger
 __ulp_trigger:
     nop

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -430,7 +430,9 @@ TESTS = \
   access.py \
   buildid.py \
   libpulp_messages.py \
-  relative_path.py
+  relative_path.py \
+  revert_all.py \
+  revert_and_patch.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/revert_all.py
+++ b/tests/revert_all.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('libhundreds_livepatch1.ulp')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.livepatch('libhundreds_livepatch2.ulp')
+
+child.sendline('hundred')
+child.expect('300', reject=['100', '200'])
+
+child.livepatch('libhundreds_livepatch3.ulp')
+
+child.sendline('hundred')
+child.expect('400', reject=['100', '200', '300'])
+
+child.livepatch(revert_lib="libhundreds.so.0")
+
+child.sendline('hundred')
+child.expect('100', reject=['200', '300', '400']);
+
+child.close(force=True)
+exit(0)

--- a/tests/revert_and_patch.py
+++ b/tests/revert_and_patch.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('libhundreds_livepatch1.ulp')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.livepatch('libhundreds_livepatch2.ulp')
+
+child.sendline('hundred')
+child.expect('300', reject=['100', '200'])
+
+child.livepatch(revert_lib="libhundreds.so.0")
+
+child.sendline('hundred')
+child.expect('100', reject=['200', '300', '400']);
+
+child.livepatch('libhundreds_livepatch3.ulp')
+
+child.sendline('hundred')
+child.expect('400', reject=['100', '200', '300'])
+
+child.close(force=True)
+exit(0)

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -125,6 +125,7 @@ struct ulp_dynobj
   Elf64_Addr state;
   Elf64_Addr global;
   Elf64_Addr msg_queue;
+  Elf64_Addr revert_all;
   /* end FIXME.  */
 
   struct thread_state *thread_states;
@@ -172,6 +173,8 @@ int set_path_buffer(struct ulp_process *process, const char *path);
 int patch_applied(struct ulp_process *process, unsigned char *id, int *result);
 
 int apply_patch(struct ulp_process *process, const char *metadata);
+
+int revert_patches_from_lib(struct ulp_process *, const char *);
 
 int restore_threads(struct ulp_process *process);
 


### PR DESCRIPTION
A new option is available for trigger: `--revert-all`. Usage:
```
$ ulp trigger -p $pid --revert-all $libname $metadata
```
`--revert-all` causes trigger to revert all patches applied to `$libname` in
the target process with pid `$pid`.

In case `--revert-all` is provided,  `$metadata is optional`. In case the
metadata is provided with patch content, the new patch will be atomically
applied to the process after all older patches have been reverted, so
the target process doesn't get a chance to run the unpatched version of
the function. If `$metadata` is not provided, no patch will be applied
after removal.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>
Co-authored-by: Simon Lees <sflees@suse.de>