### PR TITLE
Bump deadlock attempts to 10000

### DIFF
--- a/tests/deadlock.py
+++ b/tests/deadlock.py
@@ -42,7 +42,7 @@ for attempt in range(32):
   # such, should not make calls to Asynchronous Signal Unsafe functions.
   # However, libpulp calls dlopen, which is AS-Unsafe.
   try:
-    child.livepatch('libblocked_livepatch1.ulp', retries=100, timeout=20)
+    child.livepatch('libblocked_livepatch1.ulp', retries=10000, timeout=20)
   except subprocess.TimeoutExpired:
     print('Deadlock detected.')
     errors = 1


### PR DESCRIPTION
deadlock.py tests had a chance to fail because it finished all attempts
of livepatching before timing out. Previous value did work because the
ptrace functions were slow, but now they are optimized and livepatching
can be very fast.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>