### PR TITLE
Avoid opening target library for patching

### DIFF
--- a/include/interpose.h
+++ b/include/interpose.h
@@ -21,3 +21,7 @@
 
 int __ulp_asunsafe_trylock(void);
 int __ulp_asunsafe_unlock(void);
+
+void *get_loaded_symbol_addr(const char *, const char *);
+
+void *get_loaded_library_base_addr(const char *);

--- a/include/ulp.h
+++ b/include/ulp.h
@@ -52,7 +52,6 @@ struct ulp_detour_root
 {
   unsigned int index;
   void *patched_addr;
-  void *handler;
   struct ulp_detour_root *next;
   struct ulp_detour *detours;
 };

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -61,7 +61,6 @@ struct ulp_object
   uint32_t build_id_check;
   char *build_id;
   char *name;
-  void *dl_handler;
   void *flag;
   uint32_t nunits;
   struct ulp_unit *units;

--- a/tests/access.c
+++ b/tests/access.c
@@ -31,6 +31,7 @@ main(void)
   char buffer[128];
 
   /* Original banner. */
+  printf("Banner addr: 0x%lX\n", (unsigned long)banner_get());
   printf("%s\n", banner_get());
 
   /* Use original banner setting function. */

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -96,7 +96,6 @@ debug_ulp_object(struct ulp_object *obj)
   DEBUG("obj->build_id_check: %u", obj->build_id_check);
   DEBUG("obj->build id: %lx", (unsigned long)obj->build_id);
   DEBUG("obj->name: %s", obj->name);
-  DEBUG("obj->dl_handler: %lx", (unsigned long)obj->dl_handler);
   DEBUG("obj->flags: %lx", (unsigned long)obj->flag);
   DEBUG("obj->nunits: %u", obj->nunits);
   DEBUG("obj->units: %lx", (unsigned long)obj->units);


### PR DESCRIPTION
Target libraries are already opened by target process, so there is no
point in opening them again.

This also fix a patching issue if the target .so file is not found, but
it was already loaded by the process.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.com>