### PR TITLE
Block livepatching if fatal error is found

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,4 +17,4 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-noinst_HEADERS = ulp.h ulp_common.h interpose.h msg_queue.h
+noinst_HEADERS = ulp.h ulp_common.h interpose.h msg_queue.h error.h

--- a/include/error.h
+++ b/include/error.h
@@ -1,0 +1,111 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ERROR_H
+#define ERROR_H
+
+#include <stdbool.h>
+
+/* Error checking routines.  */
+
+/** @brief The error which made libpulp want to quit.  */
+
+typedef enum
+{
+  ULP_ERROR_NONE,    /** No error occurred (success).  */
+  ULP_ERROR_UNKNOWN, /** Unknown error occured.  */
+} ulp_error_t;
+
+void exit(int);
+
+/** @brief Get libpulp error state.
+ *
+ * If a fatal error has occured, libpulp cannot continue livepatching processes
+ * because it may be into an unexpected state.  This function queries if
+ * libpulp is in an error state.
+ **/
+ulp_error_t get_libpulp_error_state(void);
+
+/** @brief Check if libpulp is in an fatal error state.
+ *
+ * If a fatal error has occured, libpulp cannot continue livepatching processes
+ * because it may be into an unexpected state.
+ *
+ * @return true if in error state, false if not.
+ **/
+bool libpulp_is_in_error_state(void);
+
+/** @brief Assert that the following expression is true.  */
+void libpulp_assert_func(const char *file, const char *func, int line,
+                         unsigned long expression);
+
+/** @brief Macro which passes the current file, function and line number for
+ * logging.  */
+#define libpulp_assert(expr) \
+  libpulp_assert_func(__FILE__, __func__, __LINE__, (unsigned long)expr)
+
+/** @brief Libpulp's version of `errx`
+ *
+ *  This function works like libc's `errx`, however instead of quiting the
+ *  process it put libpulp into a state that livepatches are blocked.
+ * */
+void libpulp_errx_func(const char *file, const char *func, int line, int eval,
+                       const char *fmt, ...);
+
+/** @brief Macro which passes the current file, function and line number for
+ * logging.  */
+#define libpulp_errx(...) \
+  libpulp_errx_func(__FILE__, __func__, __LINE__, __VA_ARGS__)
+
+/** @brief Libpulp's version of `exit`
+ *
+ *  This function works like libc's `exit`, however instead of quiting the
+ *  process it put libpulp into a state that livepatches are blocked.
+ * */
+void libpulp_exit_func(const char *file, const char *func, int line, int val);
+
+#define libpulp_exit(val) libpulp_exit_func(__FILE__, __func__, __LINE__, val)
+
+/** @brief This function will indeed crash the process with an error message.
+ *
+ * Should be used with care. This should be used when the library is
+ * initializing and something really bad happened (e.g. dlsym not found, which
+ * means malloc can't be called in the original process. That certainly will
+ * turns into a disaster so it is better to crash in the beginning rather than
+ * trying to continue the user's process.
+ **/
+void __attribute__((noreturn)) libpulp_crash(const char *fmt, ...);
+
+/** @brief Assert that the following expression is true.  Crash the program if
+ * not.  */
+void libpulp_crash_assert_func(const char *file, const char *func, int line,
+                               unsigned long expression);
+
+#define libpulp_crash_assert(expr) \
+  libpulp_crash_assert_func(__FILE__, __func__, __LINE__, (unsigned long)expr)
+
+/** Poison any function that makes the process to abort.  */
+#ifdef assert
+#undef assert
+#endif
+#pragma GCC poison errx exit assert abort
+
+#endif /* ERROR_H  */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,7 +19,13 @@
 
 lib_LTLIBRARIES = libpulp.la
 
-libpulp_la_SOURCES = ulp.c interpose.c msg_queue.c ulp_prologue.S ulp_interface.S
+libpulp_la_SOURCES = \
+  ulp.c \
+  interpose.c \
+  msg_queue.c \
+  error.c \
+  ulp_prologue.S \
+  ulp_interface.S
 libpulp_la_DEPENDENCIES= libpulp.versions
 libpulp_la_LDFLAGS = \
   -ldl \

--- a/lib/error.c
+++ b/lib/error.c
@@ -1,0 +1,113 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void exit(int);
+
+/** @brief This should be the only way possible to exit the process if needed.
+ *
+ * Only use it on a catastrophic failure.
+ **/
+static inline __attribute__((noreturn)) void
+__libpulp_unique_exit_point()
+{
+  exit(1);
+}
+
+#include "error.h"
+#include "msg_queue.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+/** Holds the current error state.  */
+static ulp_error_t libpulp_error_state = ULP_ERROR_NONE;
+
+ulp_error_t
+get_libpulp_error_state()
+{
+  return libpulp_error_state;
+}
+
+bool
+libpulp_is_in_error_state()
+{
+  return !(get_libpulp_error_state() == ULP_ERROR_NONE);
+}
+
+void
+libpulp_assert_func(const char *file, const char *func, int line,
+                    unsigned long expression)
+{
+  if (expression)
+    return;
+
+  msgq_push("In file = %s, function = %s, line = %d: assertion failure: %lu\n",
+            file, func, line, expression);
+  libpulp_error_state = ULP_ERROR_UNKNOWN;
+}
+
+void
+libpulp_errx_func(const char *file, const char *func, int line, int eval,
+                  const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  msgq_push("In file = %s, function = %s, line = %d: errx : %d ;; ", file,
+            func, line, eval);
+  msgq_push(fmt, args);
+  va_end(args);
+
+  libpulp_error_state = ULP_ERROR_UNKNOWN;
+}
+
+void
+libpulp_exit_func(const char *file, const char *func, int line, int val)
+{
+  msgq_push("In file = %s, function = %s, line = %d: exit: %d\n", file, func,
+            line, val);
+
+  libpulp_error_state = ULP_ERROR_UNKNOWN;
+}
+
+void
+libpulp_crash(const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+
+  __libpulp_unique_exit_point();
+}
+
+void
+libpulp_crash_assert_func(const char *file, const char *func, int line,
+                          unsigned long expression)
+{
+  if (expression)
+    return;
+
+  fprintf(stderr,
+          "LIBPULP CATASTROPHIC FAILURE: In file = %s, function = %s, line = "
+          "%d: assertion failure: %lu\n",
+          file, func, line, expression);
+
+  __libpulp_unique_exit_point();
+}


### PR DESCRIPTION
If a fatal error was found when livepatching, we disable the
livepatching mechanism instead of exiting the target process.

The only case when we crash the target process is if libpulp
initialization fails. It may be better to warn the user that the
livepatching capabilities is not working on process startup rather than
silently disabling it and then some sysadmin finds out that something
went wrong weeks later.

Closes #48 

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>