### PR TITLE
Add support for wildcards in trigger

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -155,6 +155,15 @@ libbuildid_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libbuildid.post
 
+# Target libraries to test static data access
+check_LTLIBRARIES += libmanyprocesses.la
+
+libmanyprocesses_la_SOURCES = libmanyprocesses.c
+libmanyprocesses_la_CFLAGS = $(TARGET_CFLAGS)
+libmanyprocesses_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libmanyprocesses.post
+
 # Live patches
 check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
@@ -172,7 +181,8 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libaddress_livepatch1.la \
                      libcontract_livepatch1.la \
                      libaccess_livepatch1.la \
-                     libbuildid_livepatch1.la
+                     libbuildid_livepatch1.la \
+                     libmanyprocesses_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -225,6 +235,9 @@ libaccess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libbuildid_livepatch1_la_SOURCES = libbuildid_livepatch1.c
 libbuildid_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libmanyprocesses_livepatch1_la_SOURCES = libmanyprocesses_livepatch1.c
+libmanyprocesses_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -276,7 +289,10 @@ METADATA = \
   libaccess_livepatch1.rev \
   libbuildid_livepatch1.dsc \
   libbuildid_livepatch1.ulp \
-  libbuildid_livepatch1.rev
+  libbuildid_livepatch1.rev \
+  libmanyprocesses_livepatch1.dsc \
+  libmanyprocesses_livepatch1.ulp \
+  libmanyprocesses_livepatch1.rev
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -295,7 +311,8 @@ EXTRA_DIST = \
   libaddress_livepatch1.in \
   libcontract_livepatch1.in \
   libaccess_livepatch1.in \
-  libbuildid_livepatch1.in
+  libbuildid_livepatch1.in \
+  libmanyprocesses_livepatch1.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -326,7 +343,8 @@ check_PROGRAMS = \
   contract \
   exception_handling \
   access \
-  buildid
+  buildid \
+  manyprocesses
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -412,6 +430,10 @@ access_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 buildid_SOURCES = buildid.c
 buildid_LDADD = libbuildid.la
 buildid_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+manyprocesses_SOURCES = manyprocesses.c
+manyprocesses_LDADD = libmanyprocesses.la
+manyprocesses_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 TESTS = \
   numserv.py \

--- a/tests/libmanyprocesses.c
+++ b/tests/libmanyprocesses.c
@@ -1,0 +1,61 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * TODO: Extend the functions and parameters to cover more parameter
+ * passing conventions of target platform ABIs.
+ */
+
+#include <stdio.h>
+
+/*
+ * According to the ABI for x86_64, the first to sixth parameters of the
+ * POINTER or INTEGER classes are passed on registers, whereas the
+ * seventh and subsequent parameters of the same class are passed on the
+ * stack. This function has eight int parameters, which cover this
+ * aspect of the ABI.
+ *
+ * NOTE: Once other platforms get supported by libpulp, this should be
+ * reviewed and extended accordingly.
+ */
+void
+int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+{
+  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h);
+}
+
+/*
+ * According to the ABI for x86_64, the first to eigth parameters of the
+ * SSE class are passed on vector registers (%xmm0 to %xmm7). Likewise,
+ * parameters that fall into the SSEUP class use the same set of
+ * registers. This function has ten float parameters, which cover this
+ * aspect of the ABI.
+ *
+ * NOTE: Once other platforms get supported by libpulp, this should be
+ * reviewed and extended accordingly.
+ */
+void
+float_params(float a, float b, float c, float d, float e, float f, float g,
+             float h, float i, float j)
+{
+  printf("%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f\n", a, b, c, d, e,
+         f, g, h, i, j);
+}

--- a/tests/libmanyprocesses_livepatch1.c
+++ b/tests/libmanyprocesses_livepatch1.c
@@ -1,0 +1,36 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+void
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+{
+  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+}
+
+void
+new_float_params(float a, float b, float c, float d, float e, float f, float g,
+                 float h, float i, float j)
+{
+  printf("%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f\n", j, i, h, g, f,
+         e, d, c, b, a);
+}

--- a/tests/libmanyprocesses_livepatch1.in
+++ b/tests/libmanyprocesses_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libmanyprocesses_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libmanyprocesses.so.0
+int_params:new_int_params
+float_params:new_float_params

--- a/tests/manyprocesses.c
+++ b/tests/manyprocesses.c
@@ -1,0 +1,51 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+void int_params(int a, int b, int c, int d, int e, int f, int g, int h);
+
+void float_params(float a, float b, float c, float d, float e, float f,
+                  float g, float h, float i, float j);
+
+int
+main(void)
+{
+  char buffer[128];
+
+  /* Loop waiting for any input. */
+  printf("Waiting for input.\n");
+  while (1) {
+    if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+      if (errno) {
+        perror("parameters");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  }
+
+  return 1;
+}

--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -18,7 +18,7 @@
 import testsuite
 import subprocess
 
-def childless_livepatch(directory, timeout=10, retries=1,
+def childless_livepatch(wildcard, timeout=10, retries=1,
             verbose=False, quiet=False, revert_lib=None):
 
     # Build command-line from arguments
@@ -26,8 +26,8 @@ def childless_livepatch(directory, timeout=10, retries=1,
     if revert_lib is not None:
       command.append("--revert-all")
       command.append(revert_lib)
-    if directory is not None:
-      command.append(directory)
+    if wildcard is not None:
+      command.append(wildcard)
       print('')
     if verbose:
       command.append('-v')
@@ -52,9 +52,9 @@ def childless_livepatch(directory, timeout=10, retries=1,
     print('Live patch applied/reverted successfully.')
 
 
-childs = [testsuite.spawn('parameters'),
-          testsuite.spawn('parameters'),
-          testsuite.spawn('parameters')]
+childs = [testsuite.spawn('manyprocesses'),
+          testsuite.spawn('manyprocesses'),
+          testsuite.spawn('manyprocesses')]
 
 
 
@@ -65,7 +65,7 @@ for child in childs:
     child.expect('1-2-3-4-5-6-7-8');
     child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-childless_livepatch(directory='./', revert_lib='libparameters.so')
+childless_livepatch(wildcard='./libmanyprocesses*', revert_lib='libmanyprocesses.so.0')
 
 for child in childs:
     child.sendline('')


### PR DESCRIPTION
Previously, trigger only supported directories when applying multiple
patches. This commit add support wildcards instead, which is more
versatile.

This also fixes a race condition on manyprocesses.py test.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>