### PR TITLE
Fix (some) race conditions in testsuite

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -317,12 +317,6 @@ EXTRA_DIST = \
 clean-local:
 	rm -f $(METADATA)
 
-# There is a race condition within tests.  Some of them delete files used by
-# other tests, other try to patch a process which is yet to be patched by a
-# test. Enforcing that tests runs serially avoid such issues, so here we do
-# so it. We may have to fix it in the future if this project grows (issue #82).
-.NOTPARALLEL: check check-am dist-check
-
 # Test programs
 check_PROGRAMS = \
   numserv \
@@ -467,6 +461,22 @@ XFAIL_TESTS = \
   blocked.py \
   contract.py \
   hidden.py
+
+# Some tests must run serially because they may interfere with other
+# tests. We use *.log because automake rule that runs the tests are
+# the rule that generates the *.log.
+#
+# manyprocesses must run serially because it touches all processes
+# looking for libraries to patch, and for that it locks the ptrace
+# lock.
+
+SERIAL_TESTS = \
+  manyprocesses.log
+
+# Remove the test itself from the dependency list.
+MANYPROCESSES_DEPS = $(filter-out $(SERIAL_TESTS),$(TEST_LOGS))
+
+manyprocesses.log: $(MANYPROCESSES_DEPS)
 
 TEST_EXTENSIONS = .py
 PY_LOG_COMPILER = $(PYTHON) -B

--- a/tests/redzone.py
+++ b/tests/redzone.py
@@ -21,7 +21,7 @@
 
 import testsuite
 
-child = testsuite.spawn('redzone', timeout=10)
+child = testsuite.spawn('redzone', timeout=50)
 
 child.expect('Waiting for input.')
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -166,7 +166,8 @@ trigger_one_process(int pid, int retries, const char *livepatch,
       FATAL("fatal error during live patch application (restoring).");
       retry = 0;
     }
-    usleep(1000);
+    if (result)
+      usleep(1000);
   }
 
   if (result) {


### PR DESCRIPTION
The testsuite had some race conditions due to the new manyprocesses.py
test. There is also timeout issues which failed depending of how much
CPU is being used at the testing moment. In this commit we improve that
by:

1- Serializing manyprocesses.py, which now is run when all other tests
   are complete.
2- Increase redzone.py timeout to 50, avoiding failure when the CPU is
   too busy.

Other problems may still be around, but so far I have not found any.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>