### PR TITLE
Valgrind support

### DIFF
--- a/.github/workflows/test-suite-valgrind.yml
+++ b/.github/workflows/test-suite-valgrind.yml
@@ -1,0 +1,33 @@
+name: Test Suite with Valgrind
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: sudo apt install autoconf-archive libelf-dev python3-pexpect python3-psutil libunwind-dev valgrind
+    - name: permissions
+      run: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: ./configure --enable-stack-check --enable-valgrind
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+      id: check
+    - name: diagnostics
+      if: failure () && steps.check.outcome == 'failure'
+      run: cat tests/test-suite.log
+    - name: make distcheck
+      run: make distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AS_HELP_STRING([--enable-sanitizers],
 [compile ulp tools with address and undefined-behaviour sanitizer [default=no]]),
 [enable_sanitizers=yes]
 [AC_SUBST([UBSAN_OPTIONS], ["print_stack_trace=1 detect_stack_use_after_return=1"])],
-[enable_sanitizesr=no; break])
+[enable_sanitizers=no; break])
 
 AM_CONDITIONAL([ENABLE_ADDRSAN], [test "x$enable_sanitizers" == "xyes"])
 
@@ -63,6 +63,15 @@ AM_CONDITIONAL([ENABLE_ADDRSAN], [test "x$enable_sanitizers" == "xyes"])
 # lose interesting informations about the leaks/errors.
 AS_IF([test "x$enable_sanitizers" == "xyes"],
       [CFLAGS="-O0 -g"], [])
+
+# Enable valgrind on testing. Catches memory errors in libpulp.so.
+AC_ARG_ENABLE(valgrind,
+AS_HELP_STRING([--enable-valgrind],
+[run tests through valgrind to catch memory errors in libpulp.so [default=no]]),
+[enable_valgrind=yes],
+[enable_valgrind=no; break])
+
+AM_CONDITIONAL([ENABLE_VALGRIND], [test "x$enable_valgrind" == "xyes"])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -478,6 +478,10 @@ EXTRA_DIST += \
   testsuite.py \
   offsets.py
 
+if ENABLE_VALGRIND
+check: export TESTS_THROUGH_VALGRIND=1
+endif
+
 # Custom rule for libbuild_livepatch1.ulp. This tests if the build id
 # is correct before applying the patch. A trivial way of testing it
 # would be editing the build id from the metadata file, however, that

--- a/tests/terminal.py
+++ b/tests/terminal.py
@@ -26,7 +26,7 @@ import time
 import testsuite
 from testsuite import ulptool
 
-parent = testsuite.spawn('./terminal ./loop')
+parent = testsuite.spawn('./terminal ./loop', script=False)
 
 # Parent signal readiness first
 parent.expect('Parent ready')


### PR DESCRIPTION
Enable valgrind support on testsuite to catch memory errors in libpulp.so. This complements the current libsanitizer tests.

Closes #60 