### PR TITLE
Add support for TLS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ written with the following syntax:
 4: <old_fname_2>:<new_fname_2>
 5: #<var1>:<var1ref>:<var1_offset>:<var1ref_offset>
 6: #<var2>:<var2ref>:<var2_offset>:<var2ref_offset>
+6: #%<tlsvar1>:<tlsvar1ref>:<tlsvar1_offset>:<tlsvar1ref_offset>
 ...
 ```
 
@@ -184,5 +185,7 @@ the absolute path for the library that will be patched; it must be preceded by
 could be more lines if more functions need replacing). Lines 5 and 6 specify
 the offsets that local (not-exported) variables in the target library have from
 the beginning of the library load location, as well as the offsets of
-references to those variables in the live patch object. These offsets are used
-by Libpulp to enable access to local variables from the live patch.
+references to those variables in the live patch object. If the local variable
+line contains a %, it indicates that it is a Thread Local Storage (TLS) variable.
+These offsets are used by Libpulp to enable access to local variables from the
+live patch.

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -19,6 +19,7 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifndef _ULP_LIB_COMMON_
@@ -38,6 +39,16 @@
 #define BUILDID_LEN 20
 
 extern __thread int __ulp_pending;
+
+/** Used on __tls_get_addr(tls_index *).  */
+typedef struct
+{
+  /** Internal module index.  */
+  unsigned long ti_module;
+
+  /** Symbol index in tls section.  */
+  unsigned long ti_offset;
+} tls_index;
 
 struct ulp_patching_state
 {
@@ -90,6 +101,7 @@ struct ulp_reference
   char *reference_name;
   uintptr_t target_offset;
   uintptr_t patch_offset;
+  bool tls;
   struct ulp_reference *next;
 };
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -146,6 +146,15 @@ libaccess_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libaccess.post
 
+# Target libraries to test TLS data access
+check_LTLIBRARIES += libtls.la
+
+libtls_la_SOURCES = libtls.c
+libtls_la_CFLAGS = $(TARGET_CFLAGS)
+libtls_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libtls.post
+
 # Target libraries to test static data access
 check_LTLIBRARIES += libbuildid.la
 
@@ -181,6 +190,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libaddress_livepatch1.la \
                      libcontract_livepatch1.la \
                      libaccess_livepatch1.la \
+                     libtls_livepatch1.la \
                      libbuildid_livepatch1.la \
                      libmanyprocesses_livepatch1.la
 
@@ -231,6 +241,9 @@ libcontract_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libaccess_livepatch1_la_SOURCES = libaccess_livepatch1.c
 libaccess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+libtls_livepatch1_la_SOURCES = libtls_livepatch1.c
+libtls_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libbuildid_livepatch1_la_SOURCES = libbuildid_livepatch1.c
 libbuildid_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -287,6 +300,9 @@ METADATA = \
   libaccess_livepatch1.dsc \
   libaccess_livepatch1.ulp \
   libaccess_livepatch1.rev \
+  libtls_livepatch1.dsc \
+  libtls_livepatch1.ulp \
+  libtls_livepatch1.rev \
   libbuildid_livepatch1.dsc \
   libbuildid_livepatch1.ulp \
   libbuildid_livepatch1.rev \
@@ -311,6 +327,7 @@ EXTRA_DIST = \
   libaddress_livepatch1.in \
   libcontract_livepatch1.in \
   libaccess_livepatch1.in \
+  libtls_livepatch1.in \
   libbuildid_livepatch1.in \
   libmanyprocesses_livepatch1.in
 
@@ -343,6 +360,7 @@ check_PROGRAMS = \
   contract \
   exception_handling \
   access \
+  tls \
   buildid \
   manyprocesses
 
@@ -427,6 +445,11 @@ access_SOURCES = access.c
 access_LDADD = libaccess.la
 access_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+tls_SOURCES = tls.c
+tls_CFLAGS = -pthread $(AM_CFLAGS)
+tls_LDADD = libtls.la
+tls_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
 buildid_SOURCES = buildid.c
 buildid_LDADD = libbuildid.la
 buildid_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
@@ -456,6 +479,7 @@ TESTS = \
   exception_handling.py \
   missing_function.py \
   access.py \
+  tls.py \
   buildid.py \
   libpulp_messages.py \
   relative_path.py \

--- a/tests/libtls.c
+++ b/tests/libtls.c
@@ -19,11 +19,18 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-int __ulp_asunsafe_trylock(void);
-int __ulp_asunsafe_unlock(void);
+#include <string.h>
 
-void *get_loaded_symbol_addr(const char *, const char *);
+static __thread char *banner = "Original TLS banner";
 
-void *get_loaded_library_base_addr(const char *);
+char *
+banner_get(void)
+{
+  return banner;
+}
 
-int get_loaded_library_tls_index(const char *);
+void
+banner_set(char *new)
+{
+  banner = new;
+}

--- a/tests/libtls_livepatch1.c
+++ b/tests/libtls_livepatch1.c
@@ -19,11 +19,26 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-int __ulp_asunsafe_trylock(void);
-int __ulp_asunsafe_unlock(void);
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-void *get_loaded_symbol_addr(const char *, const char *);
+#include "../include/ulp_common.h"
 
-void *get_loaded_library_base_addr(const char *);
+// ti is overriden in the livepatching process.  It must not be declared static
+// else the compiler may remove the variable because it is unreferenced.
+tls_index ti = { 0 };
+static char *ulpr_string = "String from live patch";
 
-int get_loaded_library_tls_index(const char *);
+void *__tls_get_addr(tls_index *);
+
+void
+new_banner_set(__attribute__((unused)) char *new)
+{
+  if (ti.ti_module == 0 && ti.ti_offset == 0)
+    errx(EXIT_FAILURE, "Live patch data references not initialized");
+
+  char **ulpr_banner = __tls_get_addr(&ti);
+  printf("addr: 0x%lx\n", (unsigned long)ulpr_banner);
+  *ulpr_banner = ulpr_string;
+}

--- a/tests/libtls_livepatch1.in
+++ b/tests/libtls_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libtls_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libtls.so.0
+banner_set:new_banner_set
+#%banner:ti:__TARGET_OFFSET__:__PATCH_OFFSET__

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -46,8 +46,13 @@ for line in ifile:
   # Lines starting with '#' contain local variables
   if line[0] == '#':
 
+    # If there is a % then it is a TLS variable.
+    if line[1] == '%':
+      split = line.lstrip('#%')
+    else:
+      split = line.lstrip('#')
+
     # Parse the line
-    split = line.lstrip('#')
     split = split.split(':')
 
     # Get the name of the local variable in the target library

--- a/tests/tls.c
+++ b/tests/tls.c
@@ -1,0 +1,136 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define NUM_THREADS 2
+
+static pthread_t threads[NUM_THREADS];
+static pthread_barrier_t barrier;
+
+char *banner_get();
+void banner_set(char *);
+
+/* On two threads this should work.  If more, race conditions will appear.  */
+static volatile int gate1 = 0;
+static volatile int gate2 = 0;
+
+void *
+thread_func(void *arg)
+{
+  long i = (long)arg;
+  static __thread char buf[256];
+
+  if (i == 1) {
+    // Thread 1 must be slower and print after thread 0.
+    while (gate1 == 0)
+      usleep(1000); // Await.
+  }
+
+  /* Original banner. */
+  printf("Banner addr: 0x%lX\n", (unsigned long)banner_get());
+  printf("%s\n", banner_get());
+
+  sprintf(buf, "Banner changed from thread_func: %lu\n", i);
+
+  /* Use original banner setting function. */
+  banner_set(strdup(buf));
+  printf("%s\n", banner_get());
+
+  if (i == 0) {
+    // Allow thread 1 to run.
+    gate1++;
+  }
+
+  pthread_barrier_wait(&barrier);
+
+  if (i == 1) {
+    // Thread 1 must be slower and print after thread 0.
+    while (gate2 == 0)
+      usleep(1000); // Await.
+  }
+
+  /*
+   * Use banner setting function again, which is supposed to have been
+   * changed by the test driver. The patched function ignores the
+   * argument, so 'String from main' should not be in the output.
+   */
+
+  sprintf(buf, "String from thread_func: %lu\n", i);
+  banner_set(buf);
+  printf("%s\n", banner_get());
+
+  if (i == 0) {
+    // Allow thread 1 to run.
+    gate2++;
+  }
+
+  return NULL;
+}
+
+static void
+create_threads()
+{
+  int i;
+  for (i = 0; i < NUM_THREADS; i++) {
+    if (pthread_create(&threads[i], NULL, thread_func, (void *)((long)i))) {
+      errx(1, "Thread creation failure.");
+    }
+  }
+}
+
+static void
+join_threads()
+{
+  int i;
+  for (i = 0; i < NUM_THREADS; i++) {
+    if (pthread_join(threads[i], NULL)) {
+      errx(1, "Thread join failure.");
+    }
+  }
+}
+
+int
+main(void)
+{
+  char buffer[128];
+  pthread_barrier_init(&barrier, NULL, NUM_THREADS + 1);
+
+  create_threads();
+
+  /* Wait for input. */
+  if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+    if (errno) {
+      perror("tls");
+      return 1;
+    }
+  }
+
+  pthread_barrier_wait(&barrier);
+  join_threads();
+
+  return 0;
+}

--- a/tests/tls.py
+++ b/tests/tls.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn(testsuite.testname)
+
+child.expect('Original TLS banner')
+child.expect('Banner changed from thread_func: 0')
+child.expect('Banner changed from thread_func: 1')
+
+child.livepatch('libtls_livepatch1.ulp')
+
+child.sendline('')
+child.expect('String from live patch',
+        reject=['String from thread_func: 0',
+                'String from thread_func: 1',
+                'Live patch data references not initialized'])
+
+child.close(force=True)
+exit(0)

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -308,6 +308,7 @@ create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename)
     fwrite(ref->reference_name, sizeof(char), len, file);
     fwrite(&ref->target_offset, sizeof(ref->target_offset), 1, file);
     fwrite(&ref->patch_offset, sizeof(ref->patch_offset), 1, file);
+    fwrite(&ref->tls, sizeof(ref->tls), 1, file);
     fflush(file);
   }
 
@@ -459,6 +460,13 @@ parse_description(const char *filename, struct ulp_metadata *ulp)
         if (!ref) {
           WARN("Unable to allocate memory");
           return 0;
+        }
+
+        if (first[1] == '%') {
+          ref->tls = true;
+        }
+        else {
+          ref->tls = false;
         }
 
         third = first + 1;


### PR DESCRIPTION
TLS variables (declared with __thread keyword) are global variables
private to each thread.  They are implemented by allocating a new
variable every time a thread is spawn.

To reference an TLS variable on a livepatch, one can use the following
notation:

where `banner` is the original TLS variable we want to reference, and `ti`
is a variable that will holds the TLS offset metadata required to access
banner. Note that ti is not a pointer or reference, but a instance of
`tls_index`.

To reference the original TLS variable, one can write:

```
void *__tls_get_addr(tls_index *);
void *reference_to_banner = __tls_get_addr(&ti);
```

and then `reference_to_banner` will contain a pointer to the original var
in current thread.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>