### PR TITLE
Add initial support for livepatching functions in process

### DIFF
--- a/include/interpose.h
+++ b/include/interpose.h
@@ -22,7 +22,7 @@
 int __ulp_asunsafe_trylock(void);
 int __ulp_asunsafe_unlock(void);
 
-void *get_loaded_symbol_addr(const char *, const char *);
+void *get_loaded_symbol_addr(const char *, const char *, void *);
 
 void *get_loaded_library_base_addr(const char *);
 

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -110,4 +110,8 @@ const char *get_basename(const char *);
 
 const char *buildid_to_string(const unsigned char[BUILDID_LEN]);
 
+const char *get_target_binary_name(int);
+
+const char *get_current_binary_name(void);
+
 #endif

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -758,7 +758,8 @@ ulp_apply_all_units(struct ulp_metadata *ulp)
   /* only shared objs have units, this loop never runs for main obj */
   unit = obj->units;
   while (unit) {
-    old_fun = get_loaded_symbol_addr(get_basename(obj->name), unit->old_fname);
+    old_fun = get_loaded_symbol_addr(get_basename(obj->name), unit->old_fname,
+                                     unit->old_faddr);
     if (!old_fun)
       return ENOOLDFUNC;
 
@@ -896,14 +897,18 @@ ulp_state_update(struct ulp_metadata *ulp)
       return 0;
     }
 
-    a_unit->patched_addr =
-        get_loaded_symbol_addr(basename_target, unit->old_fname);
-    if (!a_unit->patched_addr)
+    a_unit->patched_addr = get_loaded_symbol_addr(
+        basename_target, unit->old_fname, unit->old_faddr);
+    if (!a_unit->patched_addr) {
+      MSGQ_WARN("Symbol %s not found in %s.", unit->old_fname,
+                basename_target);
       return 0;
+    }
 
     a_unit->target_addr = load_so_symbol(unit->new_fname, ulp->so_handler);
-    if (!a_unit->target_addr)
+    if (!a_unit->target_addr) {
       return 0;
+    }
 
     memcpy(a_unit->overwritten_bytes, a_unit->patched_addr, 14);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -282,6 +282,9 @@ METADATA = \
   libparameters_livepatch3.dsc \
   libparameters_livepatch3.ulp \
   libparameters_livepatch3.rev \
+  libprocess_livepatch1.dsc \
+  libprocess_livepatch1.ulp \
+  libprocess_livepatch1.rev \
   librecursion_livepatch1.dsc \
   librecursion_livepatch1.ulp \
   librecursion_livepatch1.rev \
@@ -319,6 +322,7 @@ EXTRA_DIST = \
   libdozens_bsymbolic_livepatch1.in \
   libhundreds_bsymbolic_livepatch1.in \
   libparameters_livepatch1.in \
+  libprocess_livepatch1.in \
   libparameters_livepatch2.in \
   libparameters_livepatch3.in \
   librecursion_livepatch1.in \
@@ -354,6 +358,7 @@ check_PROGRAMS = \
   contract \
   exception_handling \
   access \
+  process \
   tls \
   buildid \
   manyprocesses
@@ -369,6 +374,10 @@ numserv_bsymbolic_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 parameters_SOURCES = parameters.c
 parameters_LDADD = libparameters.la
 parameters_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+process_SOURCES = process.c
+process_CFLAGS = -fpatchable-function-entry=16,14 $(AM_CFLAGS)
+process_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 syscall_restart_SOURCES = syscall_restart.c
 syscall_restart_LDADD = libparameters.la
@@ -452,6 +461,9 @@ manyprocesses_SOURCES = manyprocesses.c
 manyprocesses_LDADD = libmanyprocesses.la
 manyprocesses_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+process_SOURCES = process.c
+process_DEPENDENCIES = $(POST_PROCESS)
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -479,12 +491,13 @@ TESTS = \
   relative_path.py \
   revert_all.py \
   revert_and_patch.py \
+  process.py \
+  process_revert.py \
   manyprocesses.py
 
 XFAIL_TESTS = \
   blocked.py \
-  contract.py \
-  hidden.py
+  contract.py
 
 # Some tests must run serially because they may interfere with other
 # tests. We use *.log because automake rule that runs the tests are
@@ -531,3 +544,5 @@ libbuildid_livepatch1.ulp: libbuildid_livepatch1.dsc $(check_LTLIBRARIES)
 	$(ULP_PACKER) $< -o $@
 	rm -f $(libbuildid_la_OBJECTS) # Clean up object again
 	$(MAKE) CFLAGS="$(CFLAGS) -DRETVAL=1338" libbuildid.la # Compile new libbuildid.
+
+libprocess_livepatch1.ulp: process libprocess_livepatch1.dsc

--- a/tests/dozens.c
+++ b/tests/dozens.c
@@ -22,7 +22,13 @@
 static int
 hidden_dozen(void)
 {
-  return 12;
+  /* Clang removes the symbol completely if it sees that it can inline the
+     function, even with -fno-inline or __attribute__((noinline)).  Even with
+     the volatile, it generates a jump to symbol rather than a function, which
+     means this function cannot be livepatched.  However, the hidden.py test
+     only check if this symbol is present in .symtab, so this is fine.  */
+  volatile int x = 12;
+  return x;
 }
 
 int

--- a/tests/libprocess_livepatch1.in
+++ b/tests/libprocess_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libparameters_livepatch1.so
+@__ABS_BUILDDIR__/process
+int_params:new_int_params
+float_params:new_float_params

--- a/tests/process.c
+++ b/tests/process.c
@@ -1,0 +1,60 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+__attribute__((noinline)) void
+int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+{
+  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h);
+}
+
+__attribute__((noinline)) void
+float_params(float a, float b, float c, float d, float e, float f, float g,
+             float h, float i, float j)
+{
+  printf("%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f-%.1f\n", a, b, c, d, e,
+         f, g, h, i, j);
+}
+
+int
+main(void)
+{
+  char buffer[128];
+
+  /* Loop waiting for any input. */
+  printf("Waiting for input.\n");
+  while (1) {
+    if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+      if (errno) {
+        perror("parameters");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  }
+
+  return 1;
+}

--- a/tests/process.py
+++ b/tests/process.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('process', script=False)
+
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.livepatch('libprocess_livepatch1.ulp')
+
+child.sendline('')
+child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
+             reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.close(force=True)
+exit(0)

--- a/tests/process_revert.py
+++ b/tests/process_revert.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('process', script=False)
+
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.livepatch('libprocess_livepatch1.ulp')
+
+child.sendline('')
+child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
+             reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.livepatch('libprocess_livepatch1.rev')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.close(force=True)
+exit(0)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -88,12 +88,12 @@ class spawn(pexpect.spawn):
     if testname[0] != '/':
       testname = './' + testname
 
-    if script == True:
-        # Run the wrapper script with dash.
-        testname = '/usr/bin/dash ' + testname
+    testname = '/usr/bin/sh -c ' + '\''+ testname + '\''
 
     # if TEST_THROUGH_VALGRIND environment variable is defined, append valgrind
-    # call on every command.
+    # call on testname. We actually call valgrind on the `sh` call, and it
+    # still catch memory issues while avoiding libpulp problems regarding
+    # the program actually being `valgrind` and not the test program.
     try:
         if os.environ['TESTS_THROUGH_VALGRIND'] == '1':
             testname = 'valgrind --leak-check=full ' + testname

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -44,7 +44,7 @@ int get_ulp_elf_metadata(const char *filename, struct ulp_object *obj);
 
 int get_object_metadata(Elf *elf, struct ulp_object *obj);
 
-int get_elf_tgt_addrs(Elf *elf, struct ulp_object *obj, Elf_Scn *st);
+int get_elf_tgt_addrs(Elf *, struct ulp_object *, Elf_Scn *st1, Elf_Scn *st2);
 
 int create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename);
 


### PR DESCRIPTION
Previously, libpulp only supported livepatching functions that were
available to the program through libraries.  We now expand this support
to functions that isn't provided by libraries (e.g., main).

This also adds support to patching symbols not present in .dynsym
section by looking the symbol address on .symtab during packer time.
Since we must ensure that buildid matches, we only patch if the target
process is the same during packer time.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>