### PR TITLE
Find address of reference to symbol by its name

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -190,6 +190,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libaddress_livepatch1.la \
                      libcontract_livepatch1.la \
                      libaccess_livepatch1.la \
+                     libaccess_livepatch2.la \
                      libtls_livepatch1.la \
                      libbuildid_livepatch1.la \
                      libmanyprocesses_livepatch1.la
@@ -241,6 +242,9 @@ libcontract_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libaccess_livepatch1_la_SOURCES = libaccess_livepatch1.c
 libaccess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+libaccess_livepatch2_la_SOURCES = libaccess_livepatch2.c
+libaccess_livepatch2_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libtls_livepatch1_la_SOURCES = libtls_livepatch1.c
 libtls_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -303,6 +307,9 @@ METADATA = \
   libaccess_livepatch1.dsc \
   libaccess_livepatch1.ulp \
   libaccess_livepatch1.rev \
+  libaccess_livepatch2.dsc \
+  libaccess_livepatch2.ulp \
+  libaccess_livepatch2.rev \
   libtls_livepatch1.dsc \
   libtls_livepatch1.ulp \
   libtls_livepatch1.rev \
@@ -331,6 +338,7 @@ EXTRA_DIST = \
   libaddress_livepatch1.in \
   libcontract_livepatch1.in \
   libaccess_livepatch1.in \
+  libaccess_livepatch2.in \
   libtls_livepatch1.in \
   libbuildid_livepatch1.in \
   libmanyprocesses_livepatch1.in
@@ -482,6 +490,7 @@ TESTS = \
   exception_handling.py \
   missing_function.py \
   access.py \
+  access2.py \
   tls.py \
   buildid.py \
   libpulp_messages.py \

--- a/tests/access2.c
+++ b/tests/access2.c
@@ -1,0 +1,58 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libaccess.h>
+
+int
+main(void)
+{
+  char buffer[128];
+
+  /* Original banner. */
+  printf("Banner addr: 0x%lX\n", (unsigned long)banner_get());
+  printf("%s\n", banner_get());
+
+  /* Use original banner setting function. */
+  banner_set(strdup("Banner changed from main"));
+  printf("%s\n", banner_get());
+
+  /* Wait for input. */
+  if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+    if (errno) {
+      perror("access");
+      return 1;
+    }
+  }
+
+  /*
+   * Use banner setting function again, which is supposed to have been
+   * changed by the test driver. The patched function ignores the
+   * argument, so 'String from main' should not be in the output.
+   */
+  banner_set("String from main");
+  printf("%s\n", banner_get());
+
+  return 0;
+}

--- a/tests/access2.py
+++ b/tests/access2.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('access')
+
+child.expect('Original banner')
+child.expect('Banner changed from main')
+
+child.livepatch('libaccess_livepatch2.ulp')
+
+child.sendline('')
+child.expect('String from live patch',
+             reject=['String from main',
+                     'Live patch data references not initialized'])
+
+child.close(force=True)
+exit(0)

--- a/tests/libaccess_livepatch2.c
+++ b/tests/libaccess_livepatch2.c
@@ -1,0 +1,47 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+
+#include <libaccess.h>
+
+char **ulpr_banner = NULL;
+static char *ulpr_string = "String from live patch";
+
+void
+new_banner_set(__attribute__((unused)) char *new)
+{
+  if (ulpr_banner == NULL)
+    errx(EXIT_FAILURE, "Live patch data references not initialized");
+
+  *ulpr_banner = ulpr_string;
+}
+
+/*
+ * Touch ulpr_banner so that it does not get optimized away or placed into
+ * read-only sections.
+ */
+void
+banner_disturb(void)
+{
+  ulpr_banner++;
+}

--- a/tests/libaccess_livepatch2.in
+++ b/tests/libaccess_livepatch2.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libaccess_livepatch2.so
+@__ABS_BUILDDIR__/.libs/libaccess.so.0
+banner_set:new_banner_set
+#banner:ulpr_banner

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -68,8 +68,10 @@ for line in ifile:
     poff = find_offset(patch, pname)
 
     # Replace offset template patterns with actual offsets
-    line = line.replace('__TARGET_OFFSET__', toff)
-    line = line.replace('__PATCH_OFFSET__', poff)
+    if toff is not None:
+        line = line.replace('__TARGET_OFFSET__', toff)
+    if poff is not None:
+        line = line.replace('__PATCH_OFFSET__', poff)
 
   # Write every line back to the output file
   ofile.write(line)

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1687,7 +1687,8 @@ check_livepatch_functions_matches_metadata(void)
     symbol = dlsym(container_handle, new_fname);
 
     if (!symbol) {
-      WARN("symbol %s is not present in the livepatch container.", new_fname);
+      WARN("symbol %s is not present in the livepatch container: %s",
+           new_fname, dlerror());
       ret = EINVAL;
       break;
     }

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -40,7 +40,7 @@ Elf_Scn *get_dynsym(Elf *elf);
 
 Elf_Scn *get_build_id_note(Elf *elf);
 
-int get_ulp_elf_metadata(const char *filename, struct ulp_object *obj);
+int get_ulp_elf_metadata(const char *filename, struct ulp_metadata *ulp);
 
 int get_object_metadata(Elf *elf, struct ulp_object *obj);
 


### PR DESCRIPTION
Before this patch, the user could only specify
```
 #target_symbol:target_symbol_ref:addr1:addr2
```
however, those address can change when you modify the livepatch
sourcecode. Therefore, we now support:
```
 #target_symbol:target_symbol_ref
```
and now `addr1` and `addr2` will be collected analysing the target
library and livepatch container automatically on packer time.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>