### PR TITLE
Get libpulp to compile on GCC 12

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -119,10 +119,10 @@ get_target_binary_name(int pid)
 
     snprintf(fname, sizeof(fname), "/proc/%d/cmdline", pid);
     FILE *fp = fopen(fname, "r");
-    fgets(cmdline, sizeof(cmdline), fp);
+    if (fgets(cmdline, sizeof(cmdline), fp) != NULL) {
+      strncpy(binary_name, get_basename(cmdline), PATH_MAX - 1);
+    }
     fclose(fp);
-
-    strncpy(binary_name, get_basename(cmdline), PATH_MAX - 1);
   }
 
   return binary_name;


### PR DESCRIPTION
On GCC 12, fgets return value must be catch when -Werror is specified.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>