### PR TITLE
Add better messages

### DIFF
--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -65,7 +65,7 @@ for child in childs:
     child.expect('1-2-3-4-5-6-7-8');
     child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-childless_livepatch(wildcard='./libmanyprocesses*', revert_lib='libmanyprocesses.so.0')
+childless_livepatch(wildcard='./libmanyprocesses*', verbose=True, revert_lib='libmanyprocesses.so.0')
 
 for child in childs:
     child.sendline('')

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -88,7 +88,7 @@ debug_ulp_unit(struct ulp_unit *unit)
   debug_ulp_unit(unit->next);
 }
 
-static void
+void
 debug_ulp_object(struct ulp_object *obj)
 {
   DEBUG("");
@@ -818,6 +818,8 @@ parse_main_dynobj(struct ulp_process *process)
 
   obj->filename = malloc(PATH_MAX);
   strcpy(obj->filename, get_target_binary_name(process->pid));
+
+  DEBUG("process name = %s, process pid = %d", obj->filename, process->pid);
 
   obj->next = NULL;
 
@@ -1688,8 +1690,6 @@ check_livepatch_functions_matches_metadata(void)
     return EINVAL;
   }
 
-  debug_ulp_object(ulp.objs);
-
   /* Iterate over all unit objects in the metadata file.  */
   for (curr_unit = ulp.objs->units; curr_unit != NULL;
        curr_unit = curr_unit->next) {
@@ -1779,15 +1779,17 @@ check_patch_sanity(struct ulp_process *process)
       char *buildid_str = strdup(buildid_to_string(buildid));
       char *lp_buildid = strdup(buildid_to_string((void *)ulp.objs->build_id));
 
-      WARN("livepatch buildid mismatch for %s (%s)\n"
+      WARN("pid = %d, name = %s: livepatch buildid mismatch for %s (%s)\n"
            "    expected buildid: %s\n",
-           target, buildid_str, lp_buildid);
+           process->pid, get_target_binary_name(process->pid), target,
+           buildid_str, lp_buildid);
 
       free(buildid_str);
       free(lp_buildid);
     }
     else {
-      WARN("target library (%s) not loaded.", target);
+      WARN("pid = %d, name = %s: target library (%s) not loaded.",
+           process->pid, get_target_binary_name(process->pid), target);
     }
     DEBUG("available target libraries:");
     for (d = dynobj_first(process); d != NULL; d = dynobj_next(process, d))

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -206,15 +206,18 @@ trigger_many_ulps(int pid, int retries, const char *wildcard_path,
                   const char *library, bool check_stack)
 {
   const char *wildcard = get_basename(wildcard_path);
-  char *ulp_folder_path = dirname(strdup(wildcard_path));
+  char *wildcard_path_dup = strdup(wildcard_path);
+  char *ulp_folder_path = dirname(wildcard_path_dup);
   DIR *directory = opendir(ulp_folder_path);
   struct dirent *entry;
   char buffer[ULP_PATH_LEN];
 
+  int ret = 0;
+
   if (!directory) {
     FATAL("Unable to open directory: %s", ulp_folder_path);
-    free(ulp_folder_path);
-    return 1;
+    ret = 1;
+    goto wildcard_clean;
   }
 
   while ((entry = readdir(directory)) != NULL) {
@@ -262,9 +265,11 @@ trigger_many_ulps(int pid, int retries, const char *wildcard_path,
   }
 
   closedir(directory);
+  ret = 0;
 
-  free(ulp_folder_path);
-  return 0;
+wildcard_clean:
+  free(wildcard_path_dup);
+  return ret;
 }
 
 /** @brief Apply multiple live patches to all processes with libpulp loaded.


### PR DESCRIPTION
1. Remove some debugging informations that were leftover from the CI
   heisenbug.
2. Show which process failed when patching multiple processes.
3. Fix a small bug which made trigger crash after patching multiple
   processes.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>