### PR TITLE
trigger: Fix `revert-all=LIB` without -p

### DIFF
--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -73,4 +73,12 @@ for child in childs:
     child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
                  reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
+childless_livepatch(wildcard=None, verbose=True, revert_lib='libmanyprocesses.so.0')
+
+for child in childs:
+    child.sendline('')
+    child.expect('1-2-3-4-5-6-7-8', reject='8-7-6-5-4-3-2-1');
+    child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0',
+                 reject='10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0');
+
     child.close(force=True)

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1686,7 +1686,8 @@ check_livepatch_functions_matches_metadata(void)
   container_handle = dlopen(so_filename, RTLD_LOCAL | RTLD_LAZY);
 
   if (!container_handle) {
-    WARN("failed to load container livepatch file in %s.", so_filename);
+    WARN("failed to load container livepatch file in %s: %s.", so_filename,
+         dlerror());
     return EINVAL;
   }
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -298,8 +298,23 @@ trigger_many_processes(int retries, const char *ulp_folder_path,
 
   /* Iterate over the process list that have libpulp preloaded.  */
   for (curr_item = list; curr_item != NULL; curr_item = curr_item->next) {
-    int r = trigger_many_ulps(curr_item->pid, retries, ulp_folder_path,
-                              library, check_stack);
+    int r;
+
+    if (ulp_folder_path) {
+      /* If a path to ulp files were provided, trigger all files that match the
+         wildcard.  */
+      r = trigger_many_ulps(curr_item->pid, retries, ulp_folder_path, library,
+                            check_stack);
+    }
+    else {
+      /* No path or wildcard provided.  The user may have requested to
+         revert-all.  */
+      r = trigger_one_process(curr_item->pid, retries, NULL, library,
+                              check_stack);
+      if (r == 0)
+        globals.trigger_successes++;
+      globals.trigger_processes++;
+    }
 
     /* If the livepatch failed because the patch wasn't targeted to the
        proccess, we ignore because we are batch processing.  */


### PR DESCRIPTION
If `revert-all=LIB` were passed to trigger without the -p parameter
and without a wildcard, then the `ulp` tool crashed with a SEGFAULT.
Add support to this case.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>