### PR TITLE
Batch rev

### DIFF
--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -65,7 +65,7 @@ for child in childs:
     child.expect('1-2-3-4-5-6-7-8');
     child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-childless_livepatch(wildcard='./libmanyprocesses*', verbose=True, revert_lib='libmanyprocesses.so.0')
+childless_livepatch(wildcard='./libmanyprocesses*.ulp', verbose=True, revert_lib='libmanyprocesses.so.0')
 
 for child in childs:
     child.sendline('')

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -249,8 +249,8 @@ trigger_many_ulps(int pid, int retries, const char *wildcard_path,
       continue;
     }
 
-    if (strcmp(extension, ".ulp")) {
-      /* This is not an ULP file, skip.  */
+    if (strcmp(extension, ".ulp") != 0 && strcmp(extension, ".rev") != 0) {
+      /* This is not an ULP or REV file, skip.  */
       continue;
     }
 


### PR DESCRIPTION
Ensure that only .ulp patches are applied in manyprocesses

In some cases, the .rev patch is applied after the .ulp, causing the
test to fail. Fix this by specifiying to patch only .ulp files.