### PR TITLE
Update patches to show more meaningful information

### DIFF
--- a/include/ulp.h
+++ b/include/ulp.h
@@ -27,26 +27,6 @@
 
 #include "ulp_common.h"
 
-/* TODO: check/remove these OLD structures */
-
-struct ulp_applied_patch
-{
-  unsigned char patch_id[32];
-  const char *lib_name;
-  struct ulp_applied_unit *units;
-  struct ulp_applied_patch *next;
-  struct ulp_dependency *deps;
-};
-
-struct ulp_applied_unit
-{
-  void *patched_addr;
-  void *target_addr;
-  char overwritten_bytes[14];
-  char jmp_type;
-  struct ulp_applied_unit *next;
-};
-
 /* ULP Structures */
 struct ulp_detour_root
 {

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -135,4 +135,6 @@ const char *get_target_binary_name(int);
 
 const char *get_current_binary_name(void);
 
+bool isnumber(const char *str);
+
 #endif

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -105,6 +105,27 @@ struct ulp_reference
   struct ulp_reference *next;
 };
 
+/* TODO: check/remove these OLD structures */
+
+struct ulp_applied_patch
+{
+  unsigned char patch_id[32];
+  const char *lib_name;
+  const char *container_name;
+  struct ulp_applied_unit *units;
+  struct ulp_applied_patch *next;
+  struct ulp_dependency *deps;
+};
+
+struct ulp_applied_unit
+{
+  void *patched_addr;
+  void *target_addr;
+  char overwritten_bytes[14];
+  char jmp_type;
+  struct ulp_applied_unit *next;
+};
+
 /* Functions present in libcommon, linked agaist both libpulp.so and tools.  */
 const char *get_basename(const char *);
 

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -868,7 +868,14 @@ ulp_state_update(struct ulp_metadata *ulp)
 
   a_patch->lib_name = strndup(get_basename(ulp->objs->name), ULP_PATH_LEN);
   if (!a_patch->lib_name) {
-    WARN("Unable to allocate filename buffer state.");
+    MSGQ_WARN("Unable to allocate filename buffer state.");
+    return 0;
+  }
+
+  a_patch->container_name =
+      strndup(get_basename(ulp->so_filename), ULP_PATH_LEN);
+  if (!a_patch->container_name) {
+    MSGQ_WARN("Unable to allocate filename buffer state.");
     return 0;
   }
 
@@ -1411,8 +1418,12 @@ dump_ulp_patching_state(void)
   int i;
 
   fprintf(stderr, "----- ULP state dump -----\n");
+  fprintf(stderr, "__ulp_state address: %lx\n", (unsigned long)&__ulp_state);
+
   for (a_patch = __ulp_state.patches; a_patch != NULL;
        a_patch = a_patch->next) {
+    fprintf(stderr, "* libname: %s\n", a_patch->lib_name);
+    fprintf(stderr, "* container: %s\n", a_patch->container_name);
     fprintf(stderr, "* PATCH 0x");
     for (i = 0; i < 32; i++) {
       fprintf(stderr, "%x.", a_patch->patch_id[i]);

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -45,7 +45,7 @@ struct arguments
   const char *livepatch;
   const char *library;
   const char *metadata;
-  pid_t pid;
+  const char *process_wildcard;
   command_t command;
   int retries;
   int quiet;

--- a/tools/check.c
+++ b/tools/check.c
@@ -19,6 +19,7 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -60,7 +61,15 @@ run_check(struct arguments *arguments)
     goto ulp_process_clean;
   }
 
-  target->pid = arguments->pid;
+  if (isnumber(arguments->process_wildcard)) {
+    target->pid = atoi(arguments->process_wildcard);
+  }
+  else {
+    WARN("check does not support process wildcard");
+    ret = -1;
+    goto ulp_process_clean;
+  }
+
   ret = initialize_data_structures(target);
   if (ret) {
     WARN("error gathering target process information.");

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -278,8 +278,7 @@ release_ulp_global_metadata(void)
  *
  *  @return The first dynobj in process.
  */
-
-static struct ulp_dynobj *
+struct ulp_dynobj *
 dynobj_first(struct ulp_process *process)
 {
   return process->dynobj_main;
@@ -289,7 +288,7 @@ dynobj_first(struct ulp_process *process)
  *
  *  @return The next dynobj in process.
  */
-static struct ulp_dynobj *
+struct ulp_dynobj *
 dynobj_next(struct ulp_process *process, struct ulp_dynobj *curr_obj)
 {
   if (curr_obj == process->dynobj_main) {

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -163,6 +163,10 @@ int parse_libs_dynobj(struct ulp_process *process);
 struct link_map *parse_lib_dynobj(struct ulp_process *process,
                                   struct link_map *link_map_addr);
 
+struct ulp_dynobj *dynobj_first(struct ulp_process *);
+
+struct ulp_dynobj *dynobj_next(struct ulp_process *, struct ulp_dynobj *);
+
 int initialize_data_structures(struct ulp_process *process);
 
 int hijack_threads(struct ulp_process *process);

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -185,6 +185,10 @@ int load_patch_info(const char *livepatch);
 
 int check_patch_sanity();
 
+struct ulp_applied_patch *ulp_read_state(struct ulp_process *);
+
+void release_ulp_applied_patch(struct ulp_applied_patch *);
+
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
 int coarse_library_range_check(struct ulp_process *process, char *library);
 #endif

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -131,7 +131,15 @@ run_messages(struct arguments *arguments)
   ulp_verbose = arguments->verbose;
   ulp_quiet = arguments->quiet;
 
-  target->pid = arguments->pid;
+  if (isnumber(arguments->process_wildcard)) {
+    target->pid = atoi(arguments->process_wildcard);
+  }
+  else {
+    WARN("messages only accepts PID when passing -p.");
+    ret = 1;
+    goto ulp_process_clean;
+  }
+
   ret = initialize_data_structures(target);
   if (ret) {
     WARN("error gathering target process information.");

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -168,8 +168,6 @@ print_process_list(struct ulp_process *process_list, int print_buildid)
 
     printf("PID: %d\n", process_item->pid);
 
-    printf("  Global universe: %ld\n", process_item->global_universe);
-
     printf("  Live patches:\n");
     object_item = process_item->dynobj_patches;
     if (!object_item)

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -165,8 +165,8 @@ print_process_list(struct ulp_process *process_list, int print_buildid)
 
   process_item = process_list;
   while (process_item) {
-
-    printf("PID: %d\n", process_item->pid);
+    pid_t pid = process_item->pid;
+    printf("PID: %d, name: %s\n", pid, get_target_binary_name(pid));
 
     printf("  Live patches:\n");
     object_item = process_item->dynobj_patches;

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/param.h>
 #include <sys/types.h>
 
 #include "arguments.h"
@@ -170,6 +171,131 @@ print_lib_patches(struct ulp_applied_patch *patch, const char *libname)
     patch = patch->next;
   }
 }
+/** @brief Check if `libname` has a livepatch loaded.
+ *
+ * Check if the library with name `libname` has a livepatch loaded in the
+ * `patch` chain.
+ *
+ * @param patch   List of loaded patches in the target process.
+ * @param libname Name of the library in target process.
+ *
+ * @return true if libname has a livepatch loaded. False elsewhere.
+ *
+ */
+static bool
+has_livepatch_loaded(struct ulp_applied_patch *patch, const char *libname)
+{
+  if (libname == NULL)
+    return false;
+
+  /* Ensure that the basename was passed.  */
+  libname = get_basename(libname);
+
+  while (patch) {
+    if (!strcmp(libname, patch->lib_name)) {
+      return true;
+    }
+    patch = patch->next;
+  }
+
+  return false;
+}
+
+/** @brief Check if function at `sym_address` has the NOP preamble.
+ *
+ * Functions that are livepatchable has ULP_NOPS_LEN - PRE_NOPS_LEN at the
+ * beginning of the function. Check the existence of this preamble.
+ *
+ * @param sym_address  Address of function in target process.
+ * @param pid          Pid of the target process.
+ *
+ * @return  True if preamble exists, false if not.
+ */
+static bool
+check_preamble(ElfW(Addr) sym_address, pid_t pid)
+{
+  int i;
+  const int num_bytes = ULP_NOPS_LEN - PRE_NOPS_LEN;
+  unsigned char bytes[num_bytes];
+
+  if (read_memory((char *)bytes, num_bytes, pid, sym_address)) {
+    WARN("Unable to read symbol preable.");
+    return false;
+  }
+
+  for (i = 0; i < num_bytes; i++) {
+    if (bytes[i] == 0x90)
+      continue;
+    else
+      break;
+  }
+
+  if (i == num_bytes)
+    return true;
+  return false;
+}
+
+/** @brief Check if library in `obj` on target process is livepatchable.
+ *
+ * Check on the target process with `pid` if the library on `obj` is
+ * livepatchable. The `patch` object with the target process loaded
+ * livepatches is necessary because the following:
+ *
+ * A library is livepatchable if their functions has the ULP NOP preamble.
+ * However, if the preamble does not exists, then:
+ * 1. The library was already livepatched, and thus is livepatchable.
+ * 2. The library is not livepatchable.
+ *
+ * @param patch  The list of patches loaded in the target process.
+ * @param obj    The libary object.
+ * @param pid    Pid of target process.
+ *
+ * @return       True if livepatchable, False if not.
+ */
+static bool
+is_library_livepatchable(struct ulp_applied_patch *patch,
+                         struct ulp_dynobj *obj, pid_t pid)
+{
+
+  if (has_livepatch_loaded(patch, obj->filename))
+    return true;
+
+  ElfW(Addr) ehdr_addr = obj->link_map.l_addr;
+
+  ElfW(Addr) dynsym_addr = obj->dynsym_addr;
+  ElfW(Addr) dynstr_addr = obj->dynstr_addr;
+  int len = obj->num_symbols;
+
+  int i, ret;
+  for (i = 0; i < len; i++) {
+    ElfW(Sym) sym;
+    char *remote_name;
+
+    ret = read_memory((char *)&sym, sizeof(sym), pid, dynsym_addr);
+    if (ret) {
+      WARN("Unable to read dynamic symbol");
+      return false;
+    }
+
+    ret = read_string(&remote_name, pid, dynstr_addr + sym.st_name);
+    if (ret) {
+      WARN("Unable to read dynamic symbol name");
+      return false;
+    }
+
+    ElfW(Addr) sym_addr = ehdr_addr + sym.st_value;
+
+    if (check_preamble(sym_addr, pid)) {
+      free(remote_name);
+      return true;
+    }
+
+    dynsym_addr += sizeof(sym);
+    free(remote_name);
+  }
+
+  return false;
+}
 
 /** @brief Prints all the info collected about the processes in `process_list`.
  *
@@ -188,20 +314,21 @@ print_process_list(struct ulp_process *process_list, int print_buildid)
     struct ulp_applied_patch *patch = ulp_read_state(process_item);
     printf("PID: %d, name: %s\n", pid, get_target_binary_name(pid));
 
-    printf("  Loaded libraries:\n");
-    object_item = process_item->dynobj_targets;
+    printf("  Livepatchable libraries:\n");
+    object_item = dynobj_first(process_item);
     if (!object_item)
       printf("    (none)\n");
     while (object_item) {
-      if (print_buildid)
-        printf("    in %s (%s):\n", object_item->filename,
-               buildid_to_string(object_item->build_id));
-      else
-        printf("    in %s:\n", object_item->filename);
+      if (is_library_livepatchable(patch, object_item, pid)) {
+        printf("    in %s", object_item->filename);
+        if (print_buildid)
+          printf(" (%s)", buildid_to_string(object_item->build_id));
+        printf(":\n");
 
-      print_lib_patches(patch, object_item->filename);
+        print_lib_patches(patch, object_item->filename);
+      }
 
-      object_item = object_item->next;
+      object_item = dynobj_next(process_item, object_item);
     }
     release_ulp_applied_patch(patch);
     process_item = process_item->next;

--- a/tools/patches.h
+++ b/tools/patches.h
@@ -27,7 +27,7 @@ struct ulp_process;
 
 const char *buildid_to_string(const unsigned char[BUILDID_LEN]);
 
-struct ulp_process *build_process_list(void);
+struct ulp_process *build_process_list(const char *wildcard);
 
 int run_patches(struct arguments *);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -286,10 +286,11 @@ wildcard_clean:
  *  @return 0 on success, anything else on error.
  */
 static int
-trigger_many_processes(int retries, const char *ulp_folder_path,
-                       const char *library, bool check_stack)
+trigger_many_processes(const char *process_wildcard, int retries,
+                       const char *ulp_folder_path, const char *library,
+                       bool check_stack)
 {
-  struct ulp_process *list = build_process_list();
+  struct ulp_process *list = build_process_list(process_wildcard);
   struct ulp_process *curr_item;
   int ret = 0;
 
@@ -343,8 +344,12 @@ run_trigger(struct arguments *arguments)
   const char *library = arguments->library;
   const char *ulp_folder_path = arguments->args[0];
   int retry = arguments->retries;
-  pid_t pid = arguments->pid;
+  const char *process_wildcard = arguments->process_wildcard;
+  pid_t pid = 0;
   int ret;
+
+  if (isnumber(process_wildcard))
+    pid = atoi(process_wildcard);
 
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   check_stack = arguments->check_stack;
@@ -353,7 +358,8 @@ run_trigger(struct arguments *arguments)
   if (pid > 0)
     ret = trigger_one_process(pid, retry, livepatch, library, check_stack);
   else {
-    ret = trigger_many_processes(retry, ulp_folder_path, library, check_stack);
+    ret = trigger_many_processes(process_wildcard, retry, ulp_folder_path,
+                                 library, check_stack);
   }
 
   return ret;

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -77,7 +77,7 @@ static struct argp_option options[] = {
   { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
   { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
   { 0, 0, 0, 0, "patches, check & trigger commands only:", 0 },
-  { "pid", 'p', "PID", 0, "Target process with PID", 0 },
+  { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
   { 0, 0, 0, 0, "dump & patches command only:", 0 },
   { "buildid", 'b', 0, 0, "Print the build id", 0 },
   { 0, 0, 0, 0, "trigger command only:", 0 },
@@ -203,8 +203,8 @@ handle_end_of_arguments(const struct argp_state *state)
       break;
 
     case ULP_MESSAGES:
-      if (arguments->pid == 0)
-        argp_error(state, "pid is mandatory in 'messages' comamnd.");
+      if (arguments->process_wildcard == 0)
+        argp_error(state, "process is mandatory in 'messages' command.");
       break;
   }
 }
@@ -225,7 +225,7 @@ parser(int key, char *arg, struct argp_state *state)
       arguments->quiet = 1;
       break;
     case 'p':
-      arguments->pid = atoi(arg);
+      arguments->process_wildcard = arg;
       break;
     case 'b':
       arguments->buildid = 1;


### PR DESCRIPTION
Instead of showing which libraries are loaded in the program,
now only show which libraries are livepatchable in the program, and
show which livepatches are loaded to that library. This should improve
readbility when querying for livepatches.

Example:
```
        in ./libssl.so.1.1:
          livepatch: libcve-2021-3449_livepatch1.so
```