### PR TITLE
Fix compilation in GCC 12

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -194,7 +194,12 @@ create_path_to_tmp_file(void)
   bool conflict = false;
   do {
     unsigned token;
-    (void)getrandom(&token, sizeof(unsigned), 0);
+    ssize_t n = getrandom(&token, sizeof(unsigned), 0);
+    if (n != sizeof(unsigned)) {
+      WARN("Failure in getrandom()");
+      return NULL;
+    }
+
     snprintf(buffer, 24, "%s%u", tmp_prefix, token);
     f = fopen(buffer, "r");
     if (f) {


### PR DESCRIPTION
osc requires that return values of functions be used. So check for
errors in getrandom.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>