### PR TITLE
Avoid reverting all patches if metadata is invalid

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -484,6 +484,7 @@ TESTS = \
   process.py \
   process_revert.py \
   livepatchable.py \
+  revert_with_invalid.py \
   manyprocesses.py \
   tempfiles.py
 

--- a/tests/revert_with_invalid.py
+++ b/tests/revert_with_invalid.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('.libs/libhundreds_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+# Now try to patch a wrong file but revert all patches associated with
+# libhundred. If there is a fail on apply and revert-all is specified,
+# it shoudn't revert the livepatches. That could imply in unsecure
+# code being run.
+
+try:
+  child.livepatch('.libs/libnonexistent_livepatch1.so', revert_lib="libhundreds.so.0", sanity=False)
+except:
+  pass
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+exit(0)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -233,11 +233,13 @@ class spawn(pexpect.spawn):
   # are optional, are the same that the Trigger tool provides (see its --help
   # output for more information).
   def livepatch(self, filename=None, timeout=10, retries=1,
-                verbose=True, quiet=False, revert=False, revert_lib=None):
+                verbose=True, quiet=False, revert=False, revert_lib=None,
+                sanity=True):
 
     # Check sanity of command-line arguments
-    self.sanity(pid=self.pid)
-    self.sanity(filename=filename)
+    if sanity is True:
+      self.sanity(pid=self.pid)
+      self.sanity(filename=filename)
 
     # Build command-line from arguments
     command = [ulptool, "trigger", '-p', str(self.pid)]
@@ -271,7 +273,8 @@ class spawn(pexpect.spawn):
 
     # The trigger tool returns 0 on success, so use check_returncode(),
     # which asserts that, and raises CalledProcessError otherwise.
-    tool.check_returncode()
+    if sanity is True:
+      tool.check_returncode()
     if revert == True:
       self.print('Live patch reverted successfully.')
     else:

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -90,7 +90,7 @@ ulp_warn(const char *format, ...)
 void
 ulp_debug(const char *format, ...)
 {
-  if (!ulp_verbose) {
+  if (ulp_verbose) {
     va_list args;
     va_start(args, format);
     vfprintf(stderr, format, args);
@@ -1527,14 +1527,14 @@ extract_ulp_from_so_to_mem(const char *livepatch, bool revert, char **out)
 
   Elf *elf = load_elf(livepatch, &fd);
   if (elf == NULL) {
-    WARN("Unable to load elf file: %s", livepatch);
     *out = NULL;
     return 0;
   }
 
   Elf_Scn *ulp_scn = get_elfscn_by_name(elf, section);
   if (ulp_scn == NULL) {
-    WARN("Unable to get section .ulp from elf %s", livepatch);
+    WARN("Unable to get section .ulp from elf %s: %s", livepatch,
+         elf_errmsg(-1));
     unload_elf(&elf, &fd);
     *out = NULL;
     return 0;
@@ -1552,7 +1552,7 @@ extract_ulp_from_so_to_mem(const char *livepatch, bool revert, char **out)
   if (meta_size >= ULP_METADATA_BUF_LEN) {
     WARN("metadata content is too large: has %u bytes, expected less than %u.",
          meta_size, ULP_METADATA_BUF_LEN);
-    return EOVERFLOW;
+    return 0;
   }
   char *final_meta = (char *)malloc(meta_size);
   char *meta_head = final_meta;

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -85,6 +85,10 @@ trigger_one_process(int pid, int retries, const char *container_path,
   if (container_path) {
     livepatch_size =
         extract_ulp_from_so_to_mem(container_path, revert, &livepatch);
+    if (livepatch == NULL || livepatch_size == 0) {
+      ret = ENOMETA;
+      goto metadata_clean;
+    }
   }
 
   if (livepatch && load_patch_info_from_mem(livepatch, livepatch_size)) {


### PR DESCRIPTION
Previously, if the metadata is invalid and --revert-all were passed,
all patches associated with library would be reverted. This behaviour
is not desired, once it would expose the target application to serious
bugs fixed in the previous patch. Block revert-all in this case.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>