### PR TITLE
Add better error messages on .dsc parser

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -23,4 +23,5 @@ noinst_HEADERS = \
 	interpose.h \
 	msg_queue.h \
 	error.h \
-	error_common.h
+	error_common.h \
+	terminal_colors.h

--- a/include/terminal_colors.h
+++ b/include/terminal_colors.h
@@ -1,0 +1,21 @@
+#ifndef _TERMINAL_COLORS_H
+#define _TERMINAL_COLORS_H
+
+#define TERM_COLOR_RED     "\x1b[31;1m"
+#define TERM_COLOR_GREEN   "\x1b[32;1m"
+#define TERM_COLOR_YELLOW  "\x1b[33;1m"
+#define TERM_COLOR_BLUE    "\x1b[34;1m"
+#define TERM_COLOR_MAGENTA "\x1b[35;1m"
+#define TERM_COLOR_CYAN    "\x1b[36;1m"
+#define TERM_COLOR_WHITE   "\x1b[37;1m"
+#define TERM_COLOR_RESET   "\x1b[0m"
+
+#define RED(str)           TERM_COLOR_RED str TERM_COLOR_RESET
+#define GREEN(str)         TERM_COLOR_GREEN str TERM_COLOR_RESET
+#define YELLOW(str)        TERM_COLOR_YELLOW str TERM_COLOR_RESET
+#define BLUE(str)          TERM_COLOR_BLUE str TERM_COLOR_RESET
+#define MAGENTA(str)       TERM_COLOR_MAGENTA str TERM_COLOR_RESET
+#define CYAN(str)          TERM_COLOR_CYAN str TERM_COLOR_RESET
+#define WHITE(str)         TERM_COLOR_WHITE str TERM_COLOR_RESET
+
+#endif //_TERMINAL_COLORS_H

--- a/tests/libparameters_livepatch2.in
+++ b/tests/libparameters_livepatch2.in
@@ -1,3 +1,2 @@
 __ABS_BUILDDIR__/.libs/libparameters_livepatch2.so
 @__ABS_BUILDDIR__/.libs/libparameters.so.0
-int_params:new_int_params

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -51,8 +51,6 @@ int create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename);
 int add_dependency(struct ulp_metadata *ulp, struct ulp_dependency *dep,
                    const char *filename);
 
-int parse_description(const char *filename, struct ulp_metadata *ulp);
-
 int get_build_id(Elf_Scn *s, struct ulp_object *obj);
 
 void *get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search);


### PR DESCRIPTION
Previously, the .dsc parser did not provide useful error messages for
the user if an error occured when parsing it. Now, we implement an
mechanism to print errors in the file that resembles GCC 5.0+. This
should improve diagnostics.

Closes #118 

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>