### PR TITLE
Improve trigger messages

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/random.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "error_common.h"
@@ -541,4 +543,14 @@ free_metadata(struct ulp_metadata *ulp)
       free(obj->build_id);
     free(obj);
   }
+}
+
+bool
+is_directory(const char *path)
+{
+  struct stat s;
+  if (stat(path, &s))
+    return false;
+  else
+    return S_ISDIR(s.st_mode);
 }

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -57,6 +57,7 @@ typedef int ulp_error_t;
 #define ENOADDRESS    274 /** Address Error.  */
 #define EAPPLIED      275 /** Patch applied.  */
 #define ENOTARGETLIB  276 /** Target library not loaded.  */
+#define EHOOKNOTRUN   277 /** libpulp.so hook routine not run.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -84,6 +85,7 @@ typedef int ulp_error_t;
     "Address read error", \
     "Patch already applied", \
     "Target library not loaded", \
+    "libpulp.so hook routine not run", \
   }
 /* clang-format on */
 

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -56,6 +56,7 @@ typedef int ulp_error_t;
 #define EDEPEND       273 /** Dependency failure.  */
 #define ENOADDRESS    274 /** Address Error.  */
 #define EAPPLIED      275 /** Patch applied.  */
+#define ENOTARGETLIB  276 /** Target library not loaded.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -81,7 +82,8 @@ typedef int ulp_error_t;
     "Patch not applied", \
     "Dependency failure", \
     "Address read error", \
-    "Patch applied", \
+    "Patch already applied", \
+    "Target library not loaded", \
   }
 /* clang-format on */
 

--- a/include/terminal_colors.h
+++ b/include/terminal_colors.h
@@ -1,21 +1,21 @@
 #ifndef _TERMINAL_COLORS_H
 #define _TERMINAL_COLORS_H
 
-#define TERM_COLOR_RED     "\x1b[31;1m"
-#define TERM_COLOR_GREEN   "\x1b[32;1m"
-#define TERM_COLOR_YELLOW  "\x1b[33;1m"
-#define TERM_COLOR_BLUE    "\x1b[34;1m"
+#define TERM_COLOR_RED "\x1b[31;1m"
+#define TERM_COLOR_GREEN "\x1b[32;1m"
+#define TERM_COLOR_YELLOW "\x1b[33;1m"
+#define TERM_COLOR_BLUE "\x1b[34;1m"
 #define TERM_COLOR_MAGENTA "\x1b[35;1m"
-#define TERM_COLOR_CYAN    "\x1b[36;1m"
-#define TERM_COLOR_WHITE   "\x1b[37;1m"
-#define TERM_COLOR_RESET   "\x1b[0m"
+#define TERM_COLOR_CYAN "\x1b[36;1m"
+#define TERM_COLOR_WHITE "\x1b[37;1m"
+#define TERM_COLOR_RESET "\x1b[0m"
 
-#define RED(str)           TERM_COLOR_RED str TERM_COLOR_RESET
-#define GREEN(str)         TERM_COLOR_GREEN str TERM_COLOR_RESET
-#define YELLOW(str)        TERM_COLOR_YELLOW str TERM_COLOR_RESET
-#define BLUE(str)          TERM_COLOR_BLUE str TERM_COLOR_RESET
-#define MAGENTA(str)       TERM_COLOR_MAGENTA str TERM_COLOR_RESET
-#define CYAN(str)          TERM_COLOR_CYAN str TERM_COLOR_RESET
-#define WHITE(str)         TERM_COLOR_WHITE str TERM_COLOR_RESET
+#define RED(str) TERM_COLOR_RED str TERM_COLOR_RESET
+#define GREEN(str) TERM_COLOR_GREEN str TERM_COLOR_RESET
+#define YELLOW(str) TERM_COLOR_YELLOW str TERM_COLOR_RESET
+#define BLUE(str) TERM_COLOR_BLUE str TERM_COLOR_RESET
+#define MAGENTA(str) TERM_COLOR_MAGENTA str TERM_COLOR_RESET
+#define CYAN(str) TERM_COLOR_CYAN str TERM_COLOR_RESET
+#define WHITE(str) TERM_COLOR_WHITE str TERM_COLOR_RESET
 
 #endif //_TERMINAL_COLORS_H

--- a/include/terminal_colors.h
+++ b/include/terminal_colors.h
@@ -8,14 +8,9 @@
 #define TERM_COLOR_MAGENTA "\x1b[35;1m"
 #define TERM_COLOR_CYAN "\x1b[36;1m"
 #define TERM_COLOR_WHITE "\x1b[37;1m"
+#define TERM_COLOR_BOLD "\x1b[;1m"
 #define TERM_COLOR_RESET "\x1b[0m"
 
-#define RED(str) TERM_COLOR_RED str TERM_COLOR_RESET
-#define GREEN(str) TERM_COLOR_GREEN str TERM_COLOR_RESET
-#define YELLOW(str) TERM_COLOR_YELLOW str TERM_COLOR_RESET
-#define BLUE(str) TERM_COLOR_BLUE str TERM_COLOR_RESET
-#define MAGENTA(str) TERM_COLOR_MAGENTA str TERM_COLOR_RESET
-#define CYAN(str) TERM_COLOR_CYAN str TERM_COLOR_RESET
-#define WHITE(str) TERM_COLOR_WHITE str TERM_COLOR_RESET
+void change_color(const char *ansi_escape);
 
 #endif //_TERMINAL_COLORS_H

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -145,6 +145,8 @@ const char *create_path_to_tmp_file(void);
 void ulp_warn(const char *, ...);
 void ulp_debug(const char *, ...);
 
+void free_metadata(struct ulp_metadata *);
+
 #define FATAL(format, ...) \
   do { \
     fprintf(stderr, "ulp: " format "\n", ##__VA_ARGS__); \

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -147,6 +147,8 @@ void ulp_debug(const char *, ...);
 
 void free_metadata(struct ulp_metadata *);
 
+bool is_directory(const char *path);
+
 #define FATAL(format, ...) \
   do { \
     fprintf(stderr, "ulp: " format "\n", ##__VA_ARGS__); \

--- a/tools/elf-extra.c
+++ b/tools/elf-extra.c
@@ -153,6 +153,10 @@ embed_patch_metadata_into_elf(Elf *elfinput, const char *elf_path,
   int fd;
   /* Load ELF with libelf to check if we already have an .ulp section.  */
   Elf *elf = load_elf(elf_path, &fd);
+  if (!elf) {
+    return EINVAL;
+  }
+
   bool ulp_section_exists = (get_elfscn_by_name(elf, section_name) != NULL);
   unload_elf(&elf, &fd);
 

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -30,6 +30,7 @@
 
 extern int ulp_verbose;
 extern int ulp_quiet;
+extern bool no_color;
 
 struct trigger_results
 {

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -31,6 +31,13 @@
 extern int ulp_verbose;
 extern int ulp_quiet;
 
+struct trigger_results
+{
+  const char *patch_name;
+  int err;
+  struct trigger_results *next;
+};
+
 struct ulp_process
 {
   int pid;
@@ -48,6 +55,9 @@ struct ulp_process
   struct ulp_dynobj *dynobj_patches;
 
   unsigned long global_universe;
+
+  /** Holds on a trigger many ulps, which patches were applied on the run.  */
+  struct trigger_results *results;
 
   struct ulp_process *next;
 };

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -44,41 +44,6 @@
 static int get_elf_tgt_ref_addrs(Elf *, struct ulp_reference *, Elf_Scn *,
                                  Elf_Scn *);
 
-void
-free_metadata(struct ulp_metadata *ulp)
-{
-  struct ulp_object *obj;
-  struct ulp_unit *unit, *next_unit;
-  struct ulp_reference *ref, *next_ref;
-  if (!ulp)
-    return;
-
-  free(ulp->so_filename);
-
-  for (ref = ulp->refs; ref != NULL; ref = next_ref) {
-    free(ref->target_name);
-    free(ref->reference_name);
-    next_ref = ref->next;
-    free(ref);
-  }
-  ulp->refs = NULL;
-
-  obj = ulp->objs;
-  if (obj) {
-    unit = obj->units;
-    while (unit) {
-      next_unit = unit->next;
-      free(unit->old_fname);
-      free(unit->new_fname);
-      free(unit);
-      unit = next_unit;
-    }
-    free(obj->name);
-    free(obj->build_id);
-    free(obj);
-  }
-}
-
 Elf_Scn *
 get_dynsym(Elf *elf)
 {

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -576,6 +576,11 @@ parse_description(const char *filename, struct ulp_metadata *ulp,
     goto dsc_clean;
   }
   fclose(file_check);
+  if (is_directory(ulp->so_filename)) {
+    parse_error(loc, "livepatch container path is not a file");
+    ret = 0;
+    goto dsc_clean;
+  }
 
   free(first);
   first = NULL;
@@ -621,7 +626,7 @@ parse_description(const char *filename, struct ulp_metadata *ulp,
         ret = 0;
         goto dsc_clean;
       }
-
+      loc.col++;
       ulp->objs = calloc(1, sizeof(struct ulp_object));
       if (!ulp->objs) {
         parse_error(loc, "unable to allocate memory for parsing ulp object.");
@@ -637,6 +642,20 @@ parse_description(const char *filename, struct ulp_metadata *ulp,
         ulp->objs->name = strdup(&first[1]);
       ulp->objs->nunits = 0;
       last_unit = NULL;
+
+      FILE *file_check = fopen(ulp->objs->name, "r");
+      if (file_check == NULL) {
+        parse_error(loc, "unable to open target file");
+        ret = 0;
+        goto dsc_clean;
+      }
+      fclose(file_check);
+
+      if (is_directory(ulp->objs->name)) {
+        parse_error(loc, "target path is not a file");
+        ret = 0;
+        goto dsc_clean;
+      }
 
       target.path = ulp->objs->name;
       target.elf = load_elf(target.path, &target.fd);

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -359,8 +359,12 @@ parse_error(location_t loc, const char *fmt, ...)
   size_t line_size;
   size_t len;
 
-  printf(WHITE("%s:%d:%d: ") RED("error: "), parse_filename, loc.line,
-         loc.col);
+  change_color(TERM_COLOR_BOLD);
+  printf("%s:%d:%d: ", parse_filename, loc.line, loc.col);
+  change_color(TERM_COLOR_RED);
+  printf("error: ");
+  change_color(TERM_COLOR_RESET);
+
   va_start(arglist, fmt);
   vprintf(fmt, arglist);
   va_end(arglist);
@@ -383,7 +387,7 @@ parse_error(location_t loc, const char *fmt, ...)
     }
 
     unsigned redchars = 0;
-    printf(TERM_COLOR_RED);
+    change_color(TERM_COLOR_RED);
     for (; j < len; j++) {
       if (line[j] == ':') {
         if (line[loc.col - 1] == ':') {
@@ -398,7 +402,7 @@ parse_error(location_t loc, const char *fmt, ...)
         redchars++;
       }
     }
-    printf(TERM_COLOR_RESET);
+    change_color(TERM_COLOR_RESET);
 
     for (; j < len; j++) {
       if (line[j] != '\n')
@@ -411,12 +415,12 @@ parse_error(location_t loc, const char *fmt, ...)
       putchar(' ');
     }
 
-    printf(TERM_COLOR_RED);
+    change_color(TERM_COLOR_RED);
     putchar('^');
     for (j = 1; j < redchars; j++) {
       putchar('~');
     }
-    printf(TERM_COLOR_RESET);
+    change_color(TERM_COLOR_RESET);
   }
 
   free(line);

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -30,8 +30,6 @@
 
 struct arguments;
 
-void free_metadata(struct ulp_metadata *ulp);
-
 void unload_elf(Elf **elf, int *fd);
 
 Elf *load_elf(const char *obj, int *fd);

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -157,7 +157,8 @@ build_process_list(const char *wildcard)
 
     const char *process_name = get_target_binary_name(pid);
     /* Skip processes that does not match the wildcard. */
-    if (wildcard != NULL && fnmatch(wildcard, process_name, 0) != 0)
+    if (wildcard != NULL && process_name != NULL &&
+        fnmatch(wildcard, process_name, 0) != 0)
       continue;
 
     /* If process is the ULP tool itself, skip it.  We cannot livepatch the


### PR DESCRIPTION
Trigger messages can be quite complicated to understand because of the
huge amount of information displayed on screen.

We now refactor this to provide more simplified messages:

For instance, when triggering all processes with the patches in current
directory:

```
$ ulp trigger '*.so'

Summary:
  ulp-test (pid: 25606):
    SKIPPED ./cve-2022-0778_livepatch1-1.1.1l-150400.2.47.so: Build ID mismatch
    SKIPPED ./cve-2022-0778_livepatch1-1.1.1l-150400.3.4.so: Build ID mismatch
    SKIPPED ./cve-2022-0778_livepatch1-1.1.1l-150400.3.11.so: Build ID mismatch
    SKIPPED ./cve-2022-0778_livepatch1-1.1.1l-150400.3.3.so: Build ID mismatch
    SKIPPED ./cve-2022-0778_livepatch1-1.1.1l-150400.3.15.so: Build ID mismatch
```

Or when asking to revert all patches to libcrypto.so to all processes:
```
ulp trigger --revert-all=libcrypto.so

Summary:
  ulp-test (pid: 25606):
    SUCCESS reverted all patches from libcrypto.so
```

Or when a trigger to a single process fails with build id mismatch:

```
$ ulp trigger -p $(pidof ulp-test) cve-2022-0778_livepatch1-1.1.1l-150400.3.15.so

error: could not apply cve-2022-0778_livepatch1-1.1.1l-150400.3.15.so to ulp-test (pid 25606): Build ID mismatch
note: run `ulp patches -b` to retrieve all build ids from patchable processes.
```

This should improve readability all across the board.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>