### PR TITLE
Endbr64 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,14 @@ AC_MSG_ERROR(
 AX_CHECK_COMPILE_FLAG([-fpatchable-function-entry=1],, AC_MSG_ERROR([\
 Required compiler option missing: -fpatchable-function-entry]))
 
+# Check if the compiler provides the -fcf-protection=full option,
+# needed to test functions with endbr64 prologue.
+AX_CHECK_COMPILE_FLAG([-fcf-protection=full], [fcf_protection="yes"], [fcf_protection="no"])
+AC_SUBST([FCF_PROTECTION], [""])
+AS_IF([test "x$fcf_protection" == "xyes"],
+  [AC_SUBST([FCF_PROTECTION], ["-fcf-protection=full"])],
+  [AC_MSG_WARN([-fcf-protection=full not supported. Full testsuite coverage not possible])])
+
 # The following headers are required to build libpulp's tools.
 AC_CHECK_HEADER([gelf.h],,
 AC_MSG_ERROR([Libelf development files are missing.]))

--- a/configure.ac
+++ b/configure.ac
@@ -178,10 +178,16 @@ AC_SUBST([PAGE_SIZE], [$($GETCONF PAGE_SIZE)]))
 # instructions that redirect execution to the universe handling routines.
 AC_SUBST([ULP_NOPS_LEN], [16])
 AC_SUBST([PRE_NOPS_LEN], [14])
+
+AC_SUBST([ULP_NOPS_LEN_ENDBR64], [$(expr $ULP_NOPS_LEN + 4)])
+AC_SUBST([PRE_NOPS_LEN_ENDBR64], [$(expr $PRE_NOPS_LEN + 4)])
+
 AC_DEFINE_UNQUOTED([ULP_NOPS_LEN], [$ULP_NOPS_LEN],
 [Total number of padding nops])
 AC_DEFINE_UNQUOTED([PRE_NOPS_LEN], [$PRE_NOPS_LEN],
 [Padding nops before the entry point of functions])
+AC_DEFINE_UNQUOTED([ULP_NOPS_LEN_ENDBR64], [$ULP_NOPS_LEN_ENDBR64],
+[Total number of padding nops when endbr64 is issued])
 
 AC_CONFIG_FILES([Makefile
 		 include/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([libpulp], [0.2.2], [noreply@suse.com])
+AC_INIT([libpulp], [0.2.3], [noreply@suse.com])
 
 # Keep most generated files under the config directory.
 AC_CONFIG_AUX_DIR([config])

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -58,6 +58,7 @@ typedef int ulp_error_t;
 #define EAPPLIED      275 /** Patch applied.  */
 #define ENOTARGETLIB  276 /** Target library not loaded.  */
 #define EHOOKNOTRUN   277 /** libpulp.so hook routine not run.  */
+#define ENOPATCHABLE  278 /** Function is not livepatchable.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -86,6 +87,7 @@ typedef int ulp_error_t;
     "Patch already applied", \
     "Target library not loaded", \
     "libpulp.so hook routine not run", \
+    "Function is not livepatchable", \
   }
 /* clang-format on */
 

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -39,6 +39,9 @@
 /** Length of build id, in bytes.  */
 #define BUILDID_LEN 20
 
+/** Intel endbr64 instruction optcode.  */
+#define INSN_ENDBR64 0xf3, 0x0f, 0x1e, 0xfa
+
 extern __thread int __ulp_pending;
 
 /** Used on __tls_get_addr(tls_index *).  */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -164,6 +164,14 @@ libbuildid_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libbuildid.post
 
+check_LTLIBRARIES += libendbr64.la
+
+libendbr64_la_SOURCES = libendbr64.c
+libendbr64_la_CFLAGS = $(TARGET_CFLAGS) -fcf-protection=full
+libendbr64_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libendbr64.post
+
 # Target libraries to test static data access
 check_LTLIBRARIES += libmanyprocesses.la
 
@@ -195,6 +203,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libtls_livepatch1.la \
                      libbuildid_livepatch1.la \
                      libprocess_access_livepatch1.la \
+                     libendbr64_livepatch1.la \
                      libmanyprocesses_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
@@ -257,6 +266,9 @@ libtls_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libbuildid_livepatch1_la_SOURCES = libbuildid_livepatch1.c
 libbuildid_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libendbr64_livepatch1_la_SOURCES = libhundreds_livepatch1.c
+libendbr64_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 libprocess_access_livepatch1_la_SOURCES = process_access_livepatch1.c
 libprocess_access_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
@@ -304,6 +316,8 @@ METADATA = \
   libbuildid_livepatch1.ulp \
   libmanyprocesses_livepatch1.dsc \
   libmanyprocesses_livepatch1.ulp \
+  libendbr64_livepatch1.dsc \
+  libendbr64_livepatch1.ulp \
   libprocess_livepatch1.dsc \
   libprocess_livepatch1.ulp \
   libprocess_access_livepatch1.dsc \
@@ -329,6 +343,7 @@ EXTRA_DIST = \
   libaccess_livepatch2.in \
   libtls_livepatch1.in \
   libbuildid_livepatch1.in \
+  libendbr64_livepatch1.in \
   libmanyprocesses_livepatch1.in \
   libprocess_livepatch1.in \
   libprocess_access_livepatch1.in
@@ -360,6 +375,7 @@ check_PROGRAMS = \
   tls \
   buildid \
   process_access \
+  endbr64 \
   manyprocesses
 
 numserv_SOURCES = numserv.c
@@ -369,6 +385,10 @@ numserv_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 numserv_bsymbolic_SOURCES = numserv.c
 numserv_bsymbolic_LDADD = libdozens_bsymbolic.la libhundreds_bsymbolic.la
 numserv_bsymbolic_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+endbr64_SOURCES = endbr64.c
+endbr64_LDADD = libdozens.la libendbr64.la
+endbr64_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 parameters_SOURCES = parameters.c
 parameters_LDADD = libparameters.la
@@ -499,6 +519,7 @@ TESTS = \
   revert_with_invalid.py \
   process_access.py \
   manyprocesses.py \
+  endbr64.py \
   tempfiles.py
 
 XFAIL_TESTS = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -167,7 +167,7 @@ POST_PROCESS += .libs/libbuildid.post
 check_LTLIBRARIES += libendbr64.la
 
 libendbr64_la_SOURCES = libendbr64.c
-libendbr64_la_CFLAGS = $(TARGET_CFLAGS) -fcf-protection=full
+libendbr64_la_CFLAGS = $(TARGET_CFLAGS) $(FCF_PROTECTION)
 libendbr64_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libendbr64.post

--- a/tests/endbr64.c
+++ b/tests/endbr64.c
@@ -1,0 +1,55 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <dozens.h>
+#include <hundreds.h>
+
+int
+main(void)
+{
+  char input[64];
+
+  printf("Waiting for input.\n");
+  while (1) {
+    if (scanf("%s", input) == EOF) {
+      if (errno) {
+        perror("numserv");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    if (strncmp(input, "dozen", strlen("dozen")) == 0)
+      printf("%d\n", dozen());
+    if (strncmp(input, "hundred", strlen("hundred")) == 0)
+      printf("%d\n", hundred());
+    if (strncmp(input, "quit", strlen("quit")) == 0) {
+      printf("Quitting.\n");
+      return 0;
+    }
+  }
+
+  return 1;
+}

--- a/tests/endbr64.py
+++ b/tests/endbr64.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This test asserts that libpulp is capable of patching functions which
+# starts with endbr64 instruction on x86_64.
+
+import testsuite
+
+child = testsuite.spawn('endbr64')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('.libs/libendbr64_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.livepatch('.libs/libendbr64_livepatch1.so', revert=True)
+
+child.sendline('hundred')
+child.expect('100', reject=['200', '300', '400']);
+
+child.close(force=True)
+exit(0)

--- a/tests/libendbr64.c
+++ b/tests/libendbr64.c
@@ -1,0 +1,26 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+int
+hundred(void)
+{
+  return 100;
+}

--- a/tests/libendbr64_livepatch1.in
+++ b/tests/libendbr64_livepatch1.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libendbr64_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libendbr64.so.0
+hundred:two_hundreds


### PR DESCRIPTION

    Add support to functions starting with endbr64 instruction
    
    Some functions can begin with `endbr64` in order to validate indirect
    jumps in x86_64, even if -fpatchable-functions-entry is enabled on
    compilation time.
    
    For instance, on Tumbleweed's glibc, it can have:
    
    __aio_read:
      endbr64
      nop
      nop
      ...
    
    As you can see, the endbr64 insn is placed before the nop opcodes.
    Previosly, trying to patch this function would result in bad insn,
    as it expected the two nop's to be the two first insn of __aio_read.
    This patch makes libpulp check if endbr64 is present there and write
    the redirect after it.

It also closes #126 