### PR TITLE
Get libpulp to build on Tumbleweed.

### DIFF
--- a/tests/librecursion_livepatch1.c
+++ b/tests/librecursion_livepatch1.c
@@ -19,10 +19,10 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <librecursion.h>
+int (*lucas_ptr)(int) = (void *)0L;
 
 long long int
 new_recursion(long long int n)
 {
-  return lucas(n);
+  return lucas_ptr(n);
 }

--- a/tests/librecursion_livepatch1.in
+++ b/tests/librecursion_livepatch1.in
@@ -1,3 +1,4 @@
 __ABS_BUILDDIR__/.libs/librecursion_livepatch1.so
 @__ABS_BUILDDIR__/.libs/librecursion.so.0
 recursion:new_recursion
+#lucas:lucas_ptr

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1648,8 +1648,8 @@ extract_ulp_from_so_to_disk(const char *livepatch, bool revert)
   char *tmp_path = strdup(create_path_to_tmp_file());
   file = fopen(tmp_path, "wb");
   if (!file) {
-    free(tmp_path);
     WARN("Unable to open temporary file %s: %s", tmp_path, strerror(errno));
+    free(tmp_path);
     return NULL;
   }
 
@@ -1657,8 +1657,8 @@ extract_ulp_from_so_to_disk(const char *livepatch, bool revert)
     remove(tmp_path);
     fclose(file);
     free(buf);
-    free(tmp_path);
     WARN("Error writing to %s: %s", tmp_path, strerror(errno));
+    free(tmp_path);
     return NULL;
   }
 


### PR DESCRIPTION
Tumbleweed's gcc found an use-after-free bug, which is now fixed.
Also update the recursion.c testcase for it to build with the
current glibc version.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>