### PR TITLE
Do not interpose dlsym

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -24,4 +24,5 @@ noinst_HEADERS = \
 	msg_queue.h \
 	error.h \
 	error_common.h \
-	terminal_colors.h
+	terminal_colors.h \
+	ld_rtld.h

--- a/include/ld_rtld.h
+++ b/include/ld_rtld.h
@@ -1,0 +1,134 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2022 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _LD_RTLD
+#define _LD_RTLD
+
+#include <dlfcn.h>
+#include <elf.h>
+#include <link.h>
+#include <pthread.h>
+
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
+struct r_debug_extended
+{
+  struct r_debug base;
+  struct r_debug_extended *r_next;
+};
+#endif
+
+typedef struct
+{
+  pthread_mutex_t mutex;
+} __rtld_lock_recursive_t;
+
+#define __rtld_lock_define_recursive(CLASS, NAME) \
+  CLASS __rtld_lock_recursive_t NAME;
+
+#define DL_NNS 16
+#define EXTERN
+
+/* clang-format off */
+
+/**
+ * Incomplete declaration of rtld_global, taken out from glibc's
+ * sysdeps/generic/ldsodefs.h. We just need the first part of it to reach the
+ * '_dl_load_lock'.
+ *
+ * Extracted from glibc 2.31
+ *
+ */
+struct rtld_global__2_31
+{
+  struct
+  {
+    struct link_map *_ns_loaded;
+    unsigned int _ns_nloaded;
+    struct r_scope_elem *_ns_main_searchlist;
+    unsigned int _ns_global_scope_alloc;
+    unsigned int _ns_global_scope_pending_adds;
+    struct
+    {
+      __rtld_lock_define_recursive(, lock) struct
+      {
+        uint32_t hashval;
+        const char *name;
+        const ElfW(Sym) * sym;
+        const struct link_map *map;
+      } * entries;
+      size_t size;
+      size_t n_elements;
+      void (*free)(void *);
+    } _ns_unique_sym_table;
+    struct r_debug _ns_debug;
+  } _dl_ns[DL_NNS];
+  size_t _dl_nns;
+  __rtld_lock_define_recursive(EXTERN, _dl_load_lock)
+  __rtld_lock_define_recursive(EXTERN, _dl_load_write_lock)
+  unsigned long long _dl_load_adds;
+};
+
+/**
+ * Incomplete declaration of rtld_global, taken out from glibc's
+ * sysdeps/generic/ldsodefs.h. We just need the first part of it to reach the
+ * '_dl_load_lock'.
+ *
+ * Extracted from glibc 2.35.
+ *
+ */
+struct rtld_global__2_35
+{
+  struct
+  {
+    struct link_map *_ns_loaded;
+    unsigned int _ns_nloaded;
+    struct r_scope_elem *_ns_main_searchlist;
+    unsigned int _ns_global_scope_alloc;
+    unsigned int _ns_global_scope_pending_adds;
+    struct link_map *libc_map;
+    struct
+    {
+      __rtld_lock_define_recursive (, lock)
+      struct
+      {
+        uint32_t hashval;
+        const char *name;
+        const ElfW(Sym) *sym;
+        const struct link_map *map;
+      } *entries;
+      size_t size;
+      size_t n_elements;
+      void (*free) (void *);
+    } _ns_unique_sym_table;
+    struct r_debug_extended _ns_debug;
+  } _dl_ns[DL_NNS];
+  size_t _dl_nns;
+  __rtld_lock_define_recursive (EXTERN, _dl_load_lock)
+  __rtld_lock_define_recursive (EXTERN, _dl_load_write_lock)
+  __rtld_lock_define_recursive (EXTERN, _dl_load_tls_lock)
+};
+
+/* clang-format on */
+
+#undef DL_NNS
+#undef EXTERN
+
+#endif

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -41,6 +41,12 @@
 /* This header should be included last, as it poisons some symbols.  */
 #include "error.h"
 
+/* Declare internal glibc functions which are exposed. We have to use them
+   while __ulp_asunsafe_begin have not run yet.  */
+extern void *__libc_malloc(size_t);
+extern void *__libc_calloc(size_t, size_t);
+extern void __libc_free(void *);
+
 static int flag = 0;
 
 /* Memory allocation functions. */
@@ -488,7 +494,7 @@ void
 free(void *ptr)
 {
   if (real_free == NULL) {
-    munmap(ptr, 1);
+    __libc_free(ptr);
     return;
   }
 
@@ -503,8 +509,7 @@ malloc(size_t size)
   void *result;
 
   if (real_malloc == NULL) {
-    result = mmap(NULL, size, PROT_READ | PROT_WRITE,
-                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    result = __libc_malloc(size);
     return result;
   }
 
@@ -521,8 +526,7 @@ calloc(size_t nmemb, size_t size)
   void *result;
 
   if (real_calloc == NULL) {
-    result = mmap(NULL, nmemb * size, PROT_READ | PROT_WRITE,
-                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    result = __libc_calloc(nmemb, size);
     return result;
   }
 

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -13,8 +13,6 @@
     posix_memalign;
     dlopen;
     dlmopen;
-    dlsym;
-    dlvsym;
     dlclose;
     dladdr;
     dladdr1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -376,7 +376,8 @@ check_PROGRAMS = \
   buildid \
   process_access \
   endbr64 \
-  manyprocesses
+  manyprocesses \
+  dlsym
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -485,6 +486,10 @@ manyprocesses_SOURCES = manyprocesses.c
 manyprocesses_LDADD = libmanyprocesses.la
 manyprocesses_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+dlsym_SOURCES = dlsym.c
+dlsym_LDADD = -lpthread -ldl -lrt -l:ld-linux-x86-64.so.2
+dlsym_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -520,6 +525,7 @@ TESTS = \
   process_access.py \
   manyprocesses.py \
   endbr64.py \
+  dlsym_lock.py \
   tempfiles.py
 
 XFAIL_TESTS = \

--- a/tests/dlsym.c
+++ b/tests/dlsym.c
@@ -1,0 +1,322 @@
+#define _GNU_SOURCE
+#include "../include/ld_rtld.h"
+#include <dlfcn.h>
+#include <gnu/lib-names.h>
+#include <gnu/libc-version.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void *rtld_global = NULL;
+static volatile pthread_mutex_t *dl_load_lock = NULL;
+static volatile pthread_mutex_t *dl_load_write_lock = NULL;
+
+/** struct containing the parameters that will be passed to dl_find_symbol.  */
+struct dl_iterate_arg
+{
+  /* Input.  */
+
+  /** Name of the .so file to find the symbol. */
+  const char *library;
+
+  /** The name of the wanted symbol. */
+  const char *symbol;
+
+  /* Output.  */
+
+  /** The address of the symbol in the program. */
+  void *symbol_addr;
+
+  /** The address bias where the library was loaded.  */
+  uintptr_t bias_addr;
+
+  /** The TLS module index of the library.  */
+  int tls_index;
+};
+
+/** @brief Get symbol by its name
+ *
+ * Example: calling this function with name = 'printf' will return
+ * the ELF symbol referring to the printf function.
+ *
+ * @param dynsym: The symbol table.
+ * @param dynstr: The symbol string table.
+ * @param len: The length of dynsym
+ * @param name: Name of the symbol to search.
+ *
+ * @return a pointer to the wanted symbol in the symbol table.
+ */
+static Elf64_Sym *
+get_symbol_by_name(Elf64_Sym dynsym[], const char *dynstr, int len,
+                   const char *name)
+{
+  int i;
+  for (i = 0; i < len; i++) {
+    /* st_name contains the offset of the symbol's name on the dynstr table. */
+    if (!strcmp(dynstr + dynsym[i].st_name, name))
+      return &dynsym[i];
+  }
+
+  /* Symbol not found.  */
+  return NULL;
+}
+
+/** @brief dl_iterate_phdr callback.
+ *
+ * This function do the hard work into gathering the necessary informations
+ * about the symbols in the process. It works by being a callback to
+ * dl_iterate_phdr (read its manpage), which pass into "info" the ELF program
+ * headers (phdr) of:
+ *  1. The current binary.
+ *  2. Each dynamic library (.so) loaded with the program.
+ *
+ * Then it parses the structures there to find the .dynsym, .dynstr, and .hash
+ * sections containing respectively:
+ *
+ *  1. The dynamic symbol table.
+ *  2. The symbol string table with the name of each symbol.
+ *  3. The hash table (only used to find the number of symbol in .dynsym).
+ *
+ * The library name which we want to find its symbol, and the wanted symbol
+ * is passed on struct dl_iterate_arg, which is passed on the "data" argument.
+ * If library name is NULL, this function will find the first occurence of
+ * "symbol" in the entire program. The output of this function is also written
+ * on the struct pointed by "data", and it is a pointer to the symbol in the
+ * program.
+ *
+ * Good references to understeand how to parse the ELF program headers are:
+ *  1. The elf.h header.
+ *  2. 'dl_iterate_phdr' manpage.
+ *  3. 'Learing Linux Binary Analysis' (Elfmaster, 2016).
+ *  4. 'Linkers and Loaders' (Levine, 1999).
+ *
+ * @param info: Program header infos (see dl_iterate_phdr).
+ * @param size: sizeof(dl_phdr_info).
+ * @param data: Data to this function. Also used as return value.
+ *
+ * @return 1 when done; 0 to request next library.
+ */
+static int
+dl_find_symbol(struct dl_phdr_info *info, size_t size, void *data)
+{
+  /* We call the symbol table as dynsym because that is most likely to be the
+   * section in DT_SYMTAB.  However, this is not necessary true in all cases.
+   */
+  Elf64_Sym *dynsym = NULL;
+  const char *dynstr = NULL;
+  int *hash_addr;
+
+  int i;
+  int num_symbols = 0;
+  struct dl_iterate_arg *args = (struct dl_iterate_arg *)data;
+
+  /* Sanity check if size matches the size of the struct.  */
+  if (size != sizeof(*info)) {
+    abort();
+    return 0;
+  }
+
+  /* Initialize output value as being NULL (symbol not found).  */
+  args->symbol_addr = NULL;
+
+  /* Initialize TLS index with invalid value.  */
+  args->tls_index = -1;
+
+  /* Check if the current info is the library we want to find the symbols.  */
+  if (args->library && !strstr(info->dlpi_name, args->library))
+    return 0;
+
+  /* Pointers to linux-vdso.so are invalid, so skip this library.  */
+  if (!strcmp(info->dlpi_name, "linux-vdso.so.1"))
+    return 0;
+
+  /* Iterate each program headers to find the information we need. */
+  for (i = 0; i < info->dlpi_phnum; i++) {
+    const Elf64_Phdr *phdr_addr = &info->dlpi_phdr[i];
+
+    /* We are interested in symbols, so look for the dynamic symbols in the
+     * PT_DYNAMIC tag. */
+    if (phdr_addr->p_type == PT_DYNAMIC) {
+
+      /* The address in p_paddr is relative to the .so header, so we need to
+       * add the base address where the .so was mapped in the process. In case
+       * it is the binary itself, dlpi_addr is zero.  */
+      Elf64_Dyn *dyn = (Elf64_Dyn *)(info->dlpi_addr + phdr_addr->p_paddr);
+
+      /* Iterate over each tag in this section.  */
+      for (; dyn->d_tag != DT_NULL; dyn++) {
+        switch (dyn->d_tag) {
+          case DT_SYMTAB:
+            dynsym = (Elf64_Sym *)dyn->d_un.d_ptr;
+            break;
+
+          case DT_STRTAB:
+            dynstr = (const char *)dyn->d_un.d_ptr;
+            break;
+
+          case DT_SYMENT:
+            /* This section stores the size of a symbol entry. So compare it
+             * with the size of Elf64_Sym as a sanity check.  */
+            if (dyn->d_un.d_val != sizeof(Elf64_Sym)) {
+              abort();
+              return 0;
+            }
+            break;
+
+          case DT_HASH:
+            /* Look at the hash section for the number of the symbols in the
+             * symbol table.  This section structure in memory is:
+             *
+             * hash_t nbuckets;
+             * hash_t nchains;
+             * hash_t buckets[nbuckets];
+             * hash_t chain[nchains];
+             *
+             * hash_t is either int32_t or int64_t according to the arch.
+             * On x86_64 it is 32-bits.
+             * */
+            hash_addr = (int *)dyn->d_un.d_ptr;
+            num_symbols = hash_addr[1]; /* Get nchains.  */
+            break;
+        }
+      }
+    }
+  }
+
+  /* With the symbol table identified, find the wanted symbol.  */
+  if (dynstr && dynsym) {
+    Elf64_Sym *sym;
+    args->tls_index = info->dlpi_tls_modid;
+
+    sym = get_symbol_by_name(dynsym, dynstr, num_symbols, args->symbol);
+    if (sym)
+      args->symbol_addr = (void *)(info->dlpi_addr + sym->st_value);
+
+    args->bias_addr = info->dlpi_addr;
+    /* Alert dl_iterate_phdr that we are finished.  */
+    return 1;
+  }
+  return 0;
+}
+
+/** @brief Get the address of a loaded symbol from library.
+ *
+ * This function will return the address where the symbol with the name
+ * "symbol" from the library "library" was allocated in memory.
+ *
+ * Example: calling this function with symbol = "printf" will return
+ * the address where the printf function is.
+ *
+ * @param library: name of the library where the symbol is from.
+ * @param symbol: name of the wanted symbol
+ * @param old_faddr: Offset of symbol, as found during packing.
+ *
+ * @return the address where the symbol was allocated nn the program.
+ */
+void *
+get_loaded_symbol_addr(const char *library, const char *symbol,
+                       void *old_faddr)
+{
+  /* Check if the current info is the program's binary itself.  In that case
+   * we must handle things somewhat differently.  */
+  if (library == NULL) {
+    library = "";
+  }
+
+  struct dl_iterate_arg arg = { .library = library, .symbol = symbol };
+  dl_iterate_phdr(dl_find_symbol, &arg);
+
+  if (old_faddr != NULL && arg.symbol_addr != old_faddr) {
+    printf("Symbol requested not found in .dymsym. Using address from .ulp\n");
+    return arg.bias_addr + old_faddr;
+  }
+
+  return arg.symbol_addr;
+}
+
+static void
+get_ld_global_locks()
+{
+  char libc_ver[32];
+  const char *tok;
+  int major, minor;
+
+  rtld_global = get_loaded_symbol_addr(LD_SO, "_rtld_global", NULL);
+
+  if (!rtld_global) {
+    fprintf(stderr, "symbol _rtld_global not found in ld-linux-x86_64.so\n");
+    abort();
+  }
+
+  strcpy(libc_ver, gnu_get_libc_version());
+
+  tok = strtok(libc_ver, ".");
+  major = atoi(tok);
+  tok = strtok(NULL, ".");
+  minor = atoi(tok);
+
+  if (major == 2) {
+    if (31 <= minor && minor < 35) {
+      struct rtld_global__2_31 *rtld = rtld_global;
+      dl_load_lock = &rtld->_dl_load_lock.mutex;
+      dl_load_write_lock = &rtld->_dl_load_write_lock.mutex;
+    }
+    else if (35 <= minor) {
+      struct rtld_global__2_35 *rtld = rtld_global;
+      dl_load_lock = &rtld->_dl_load_lock.mutex;
+      dl_load_write_lock = &rtld->_dl_load_write_lock.mutex;
+    }
+    else {
+      fprintf(stderr, "glibc version %d.%d is unsupported\n", major, minor);
+      abort();
+    }
+  }
+}
+
+static volatile int gate = 0;
+
+void *
+observer(void *args __attribute__((unused)))
+{
+  while (1) {
+    int lock = dl_load_lock->__data.__lock;
+    if (lock == 1) {
+      printf("dl lock was acquired: %d\n", lock);
+      gate = 1;
+      return (void *)0;
+    }
+    else if (lock < 0 || lock > 1) {
+      printf("dl lock is nonsensical: %d\n", lock);
+      return (void *)1;
+    }
+  }
+
+  return (void *)1;
+}
+
+void *
+dlsym_poke(void *args __attribute__((unused)))
+{
+  while (!gate) {
+    dlsym(RTLD_DEFAULT, "malloc");
+  }
+
+  return NULL;
+}
+
+int
+main()
+{
+  unsigned long observer_ret;
+  get_ld_global_locks();
+
+  pthread_t observer_thread, dlsym_thread;
+
+  pthread_create(&observer_thread, NULL, observer, NULL);
+  pthread_create(&dlsym_thread, NULL, dlsym_poke, NULL);
+
+  pthread_join(observer_thread, (void *)&observer_ret);
+  pthread_join(dlsym_thread, NULL);
+  return (int)observer_ret;
+}

--- a/tests/dlsym_lock.py
+++ b/tests/dlsym_lock.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python3
+
 #   libpulp - User-space Livepatching Library
 #
-#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#   Copyright (C) 2022 SUSE Software Solutions GmbH
 #
 #   This file is part of libpulp.
 #
@@ -17,25 +19,13 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-lib_LTLIBRARIES = libpulp.la
+import testsuite
 
-libpulp_la_SOURCES = \
-  ulp.c \
-  interpose.c \
-  msg_queue.c \
-  error.c \
-  ulp_prologue.S \
-  ulp_interface.S
-libpulp_la_DEPENDENCIES= libpulp.versions
-libpulp_la_LDFLAGS = \
-  -ldl \
-  -l:ld-linux-x86-64.so.2 \
-  -Wl,--version-script=$(srcdir)/libpulp.versions \
-  -Wl,--hash-style=sysv \ # Ubuntu seems to default to gnu, so be clear we ...
-  $(AM_LDFLAGS) # ... want old style hash sections, else DT_HASH is empty.
+child = testsuite.spawn("dlsym", timeout=10)
 
-libpulp_la_LIBADD = $(top_builddir)/common/libcommon.la
+child.expect('dl lock was acquired: 1',
+             reject=["dl lock is nonsensical:",
+             "symbol _rtld_global not found in ld-linux-x86_64.so"])
 
-AM_CFLAGS += -I$(top_srcdir)/include
-
-EXTRA_DIST = libpulp.versions
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
Glibc's dlsym behaviour changes depending of where it is being called.
    
Proof of this can be found in glibc's dlfcn/dlsym.c. Notice that
RETURN_ADDRESS(0) is passed to internal functions, which gets the
previous frame address.
    
The practical behaviour is that if we interpose dlsym, then software
that interposes functions from glibc will find libpulp functions
instead, and libpulp will find the software interposed functions,
creating an infinite recursion.
    
Therefore, we can not interpose dlsym and use a custom lock, as we do
for the other functions, and we instead check if the dlsym lock is
held.
    
Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>
