### PR TITLE
Correctly warn about permission errors

### DIFF
--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -415,7 +415,7 @@ parse_metadata(struct ulp_metadata *ulp)
     goto metadata_clean;
 
   if (!load_so_handlers(ulp)) {
-    ret = EUNKNOWN;
+    ret = errno;
     goto metadata_clean;
   }
 


### PR DESCRIPTION
Previously, if dlopen errors out and summary is enabled, then ulp
trigger errors with "Unknown error". Fix this by returning the error
code stored in errno.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>