### PR TITLE
Refactor `stress` test

### DIFF
--- a/tests/libstress_livepatch1.c
+++ b/tests/libstress_livepatch1.c
@@ -1,4 +1,5 @@
-int new_value(void)
+int
+new_value(void)
 {
-return 2;
+  return 0;
 }

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -1,15 +1,80 @@
-#include <unistd.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define NUM_PROCESSES 1000
 
 int value(void);
 
-int main(void)
+typedef enum
 {
-  puts("Ready");
+  NONE = 0,
+  READY,
+  LIVEPATCHED,
+} state_t;
 
-  while (value() != 0) {
+int
+child_main(volatile state_t *state)
+{
+  *state = READY;
+
+  while (value()) {
     sleep(1);
   }
+
+  *state = LIVEPATCHED;
+  return 0;
+}
+
+int
+main(void)
+{
+  pid_t pids[NUM_PROCESSES];
+  volatile state_t *states;
+  states = mmap(NULL, NUM_PROCESSES * sizeof(state_t), PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+  for (int i = 0; i < NUM_PROCESSES; i++) {
+    states[i] = NONE;
+    pids[i] = fork();
+
+    if (pids[i] == 0) {
+      /* Child.  */
+      return child_main(&states[i]);
+    }
+  }
+
+  for (int i = 0; i < NUM_PROCESSES; i++) {
+    while (states[i] != READY)
+      usleep(1000);
+  }
+
+  puts("Processes launched");
+
+  for (int i = 0; i < NUM_PROCESSES; i++) {
+    while (states[i] != LIVEPATCHED)
+      usleep(1000);
+  }
+
+  for (int i = 0; i < NUM_PROCESSES; i++) {
+    int wstatus;
+    waitpid(pids[i], &wstatus, 0);
+
+    if (WIFEXITED(wstatus)) {
+      int r = WEXITSTATUS(wstatus);
+      if (r) {
+        printf("Process %d returned non-zero: %d\n", pids[i], r);
+      }
+    }
+    else {
+      printf("Process %d ended without calling exit\n", pids[i]);
+    }
+  }
+
+  munmap((void *)states, NUM_PROCESSES * sizeof(state_t));
+  puts("Processes finished");
 
   return 0;
 }

--- a/tests/stress.py
+++ b/tests/stress.py
@@ -17,20 +17,14 @@
 
 # This test stress out the ulp tool when multiple processes are running.
 
+import sys
 import testsuite
 import subprocess
 
-childs = []
-
-for i in range(1000):
-    print("launching " + str(i))
-    child = testsuite.spawn('stress')
-    childs.append(child)
-
-for child in childs:
-    child.expect('Ready')
+child = testsuite.spawn('stress')
+child.expect("Processes launched")
 
 testsuite.childless_livepatch(wildcard='.libs/libstress_livepatch1.so', verbose=False, timeout=60)
 
-for child in childs:
-    child.close(force=True)
+child.expect("Processes finished", reject=['returned non-zero'])
+child.close(force=True)


### PR DESCRIPTION
The `stress` test previously used pyexpect stdout redirection mechanism
that used an unreasonable amount of RAM (>16Gb). Refactor this test so
that it uses a single process on the .py script and everything else is
handled in `stress.c`.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>