### PR TITLE
Optimize some ulp tools mechanisms

### DIFF
--- a/tests/stress.c
+++ b/tests/stress.c
@@ -4,7 +4,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define NUM_PROCESSES 1000
+#define NUM_PROCESSES 4000
 
 int value(void);
 

--- a/tests/stress.py
+++ b/tests/stress.py
@@ -24,7 +24,7 @@ import subprocess
 child = testsuite.spawn('stress')
 child.expect("Processes launched")
 
-testsuite.childless_livepatch(wildcard='.libs/libstress_livepatch1.so', verbose=False, timeout=60)
+testsuite.childless_livepatch(wildcard='.libs/libstress_livepatch1.so', verbose=False, timeout=120)
 
 child.expect("Processes finished", reject=['returned non-zero'])
 child.close(force=True)

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1087,7 +1087,6 @@ set_id_buffer(struct ulp_process *process, unsigned char *patch_id)
 {
   struct ulp_thread *thread;
   Elf64_Addr path_addr;
-  int i;
 
   DEBUG("advertising live patch ID to libpulp.");
 
@@ -1099,11 +1098,9 @@ set_id_buffer(struct ulp_process *process, unsigned char *patch_id)
   thread = process->main_thread;
   path_addr = process->dynobj_libpulp->metadata_buffer;
 
-  for (i = 0; i < 32; i++) {
-    if (write_byte(patch_id[i], thread->tid, path_addr + i)) {
-      WARN("Unable to write id byte %d.", i);
-      return ETARGETHOOK;
-    }
+  if (write_bytes(patch_id, 32, thread->tid, path_addr)) {
+    WARN("Unable to write buildid at address %lx.", path_addr);
+    return ETARGETHOOK;
   }
 
   return 0;
@@ -1143,7 +1140,6 @@ set_string_buffer(struct ulp_process *process, const char *string)
 static int
 set_metadata_buffer(struct ulp_process *process, void *metadata, size_t size)
 {
-  size_t i;
   char *cmetadata = metadata;
 
   struct ulp_thread *thread;
@@ -1157,10 +1153,8 @@ set_metadata_buffer(struct ulp_process *process, void *metadata, size_t size)
   thread = process->main_thread;
   metadata_addr = process->dynobj_libpulp->metadata_buffer;
 
-  for (i = 0; i < size; i++) {
-    if (write_byte(cmetadata[i], thread->tid, metadata_addr + i)) {
-      return EUNKNOWN;
-    }
+  if (write_bytes(cmetadata, size, thread->tid, metadata_addr)) {
+    return EUNKNOWN;
   }
 
   return ENONE;

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -106,8 +106,19 @@ print_message_buffer(const struct ulp_process *p, bool debug)
     return 1;
   }
 
+  if (attach(p->pid)) {
+    DEBUG("unable to attach to %d to read string.", p->pid);
+    return 1;
+  }
+
   ret = read_memory((void *)&msg_queue, sizeof(struct msg_queue), p->pid,
                     msgq_addr);
+
+  if (detach(p->pid)) {
+    DEBUG("unable to detach from %d.", p->pid);
+    return 1;
+  }
+
   if (ret > 0) {
     WARN("could not read libpulp.so message queue in process %d.", p->pid);
     return 1;

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -168,8 +168,13 @@ is_library_livepatchable(struct ulp_applied_patch *patch,
   }
 
   ElfW(Addr) ehdr_addr = obj->link_map.l_addr;
-
   ElfW(Addr) dynsym_addr = obj->dynsym_addr;
+
+  if (ehdr_addr == 0) {
+    /* If l_addr is zero, it means that there is no load bias.  In that case,
+     * the elf address is on address 0x400000 on x86_64.  */
+    ehdr_addr = 0x400000UL;
+  }
 
   /* Only look the first 64 symbols, else we may take too much time.  */
   int len = MIN(obj->num_symbols, 64);

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -151,17 +151,9 @@ write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr)
  * Returns 0 if the operation succeeds; 1 otherwise.
  */
 int
-write_string(const char *buffer, int pid, Elf64_Addr addr, int size)
+write_string(const char *buffer, int pid, Elf64_Addr addr)
 {
-  size_t len = strlen(buffer);
-
-  if (len > (unsigned)size) {
-    len = size;
-  }
-
-  /* Invalidate tlb because we are commiting changes to memory.  */
-  tlb = 0;
-
+  size_t len = strlen(buffer) + 1;
   return write_bytes(buffer, len, pid, addr);
 }
 

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -68,6 +68,14 @@ ulp_ptrace(enum __ptrace_request request, pid_t pid, void *addr, void *data)
   time_t t0, t1;
   long ret;
 
+  /* Unroll first iteration to avoid calls to time if it succeeds on first try.
+   */
+  errno = 0;
+  ret = ptrace(request, pid, addr, data);
+  if (!(errno == EBUSY || errno == EPERM)) {
+    return ret;
+  }
+
   t0 = time(NULL);
   do {
     errno = 0;

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -221,11 +221,6 @@ read_memory(char *byte, size_t len, int pid, Elf64_Addr addr)
 
   long *word = (long *)byte;
 
-  if (attach(pid)) {
-    DEBUG("unable to attach to %d to read data.\n", pid);
-    return 1;
-  };
-
   /* Read as much as we can using longs, since it has larger bandwith when
      compared to bytes.  */
   for (i = 0; i < len_word; i++) {
@@ -242,11 +237,6 @@ read_memory(char *byte, size_t len, int pid, Elf64_Addr addr)
       return 1;
   }
 
-  if (detach(pid)) {
-    DEBUG("unable to detach from %d after reading data.\n", pid);
-    return 1;
-  };
-
   return 0;
 }
 
@@ -256,11 +246,6 @@ read_string(char **buffer, int pid, Elf64_Addr addr)
   int i = 0;
   char *string;
   int buffer_len;
-
-  if (attach(pid)) {
-    DEBUG("unable to attach to %d to read string.", pid);
-    return 1;
-  }
 
   buffer_len = 32;
   string = (char *)malloc(buffer_len);
@@ -279,11 +264,6 @@ read_string(char **buffer, int pid, Elf64_Addr addr)
     }
   }
   while (string[i++] != '\0');
-
-  if (detach(pid)) {
-    DEBUG("unable to detach from %d after reading string.", pid);
-    return 1;
-  };
 
   *buffer = string;
   return 0;

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -35,9 +35,7 @@ int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
 int write_string(const char *buffer, int pid, Elf64_Addr addr);
 
-int read_byte(char *byte, int pid, Elf64_Addr addr);
-
-int read_memory(char *byte, size_t len, int pid, Elf64_Addr addr);
+int read_memory(void *byte, size_t len, int pid, Elf64_Addr addr);
 
 int read_string(char **buffer, int pid, Elf64_Addr addr);
 

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -33,7 +33,7 @@
 
 int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
-int write_string(const char *buffer, int pid, Elf64_Addr addr, int length);
+int write_string(const char *buffer, int pid, Elf64_Addr addr);
 
 int read_byte(char *byte, int pid, Elf64_Addr addr);
 

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -30,7 +30,8 @@
 #include "ulp_common.h"
 
 /* Memory read/write helper functions */
-int write_byte(char byte, int pid, Elf64_Addr addr);
+
+int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
 int write_string(const char *buffer, int pid, Elf64_Addr addr, int length);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -230,6 +230,7 @@ trigger_many_ulps(struct ulp_process *p, int retries,
   char buffer[ULP_PATH_LEN];
 
   int ret = 0, r;
+  int ulp_folder_path_len = strlen(ulp_folder_path);
 
   if (!directory) {
     FATAL("Unable to open directory: %s", ulp_folder_path);
@@ -237,18 +238,23 @@ trigger_many_ulps(struct ulp_process *p, int retries,
     goto wildcard_clean;
   }
 
+  strcpy(buffer, ulp_folder_path);
+  strcat(buffer, "/");
+  ulp_folder_path_len += 1;
+
   while ((entry = readdir(directory)) != NULL) {
     struct stat stbuf;
     int bytes;
-    memset(buffer, '\0', ULP_PATH_LEN);
 
-    bytes = snprintf(buffer, ULP_PATH_LEN, "%s/%s", ulp_folder_path,
-                     entry->d_name);
-    if (bytes == ULP_PATH_LEN) {
+    bytes = ulp_folder_path_len + strlen(entry->d_name);
+
+    if (bytes >= ULP_PATH_LEN) {
       WARN("Path to %s is larger than %d bytes. Skipping...\n", entry->d_name,
            ULP_PATH_LEN);
       continue;
     }
+
+    strcpy(buffer + ulp_folder_path_len, entry->d_name);
 
     if (stat(buffer, &stbuf)) {
       WARN("Error retrieving stats for %s. Skiping...\n", buffer);


### PR DESCRIPTION
Try to reduce the execution time of `ulp trigger` and `ulp patches` when a large number of processes are loaded. Trigger now takes 20s to patch 4000 processes.