### PR TITLE
Drastically improve patching time.

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -116,7 +116,7 @@ libpulp_strerror(ulp_error_t errnum)
 const char *
 get_target_binary_name(int pid)
 {
-  static char binary_name[PATH_MAX];
+  static __thread char binary_name[PATH_MAX];
 
   char fname[PATH_MAX];
   char cmdline[PATH_MAX];

--- a/common/common.c
+++ b/common/common.c
@@ -51,7 +51,7 @@
 const char *
 get_basename(const char *name)
 {
-  const char *base = strrchr(name, '/');
+  const char *base = (name) ? strrchr(name, '/') : name;
 
   /* If strrchr returned non-null, it means that it found the last '/' in the
    * path, so add one to get the base name.  */

--- a/configure.ac
+++ b/configure.ac
@@ -59,9 +59,19 @@ AS_HELP_STRING([--enable-sanitizers],
 
 AM_CONDITIONAL([ENABLE_ADDRSAN], [test "x$enable_sanitizers" == "xyes"])
 
+# Enable thread sanitizer. It can't run together with addrsan.
+AC_ARG_ENABLE(thread-sanitizer,
+AS_HELP_STRING([--enable-thread-sanitizer],
+[compile ulp tools with thread sanitizer [default=no]]),
+[enable_thread_sanitizer=yes]
+[],
+[enable_thread_sanitizer=no; break])
+
+AM_CONDITIONAL([ENABLE_THREADSAN], [test "x$enable_thread_sanitizer" == "xyes"])
+
 # We need to disable optimizations if libsanitizer is enabled, else we
 # lose interesting informations about the leaks/errors.
-AS_IF([test "x$enable_sanitizers" == "xyes"],
+AS_IF([test "x$enable_sanitizers" == "xyes" -o "x$enable_thread_sanitizer" == "xyes"],
       [CFLAGS="-O0 -g"], [])
 
 # Enable valgrind on testing. Catches memory errors in libpulp.so.

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -22,6 +22,7 @@
 #ifndef _ULP_LIB_COMMON_
 #define _ULP_LIB_COMMON_
 
+#include <elf.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -129,6 +130,44 @@ struct ulp_applied_unit
   char jmp_type;
   struct ulp_applied_unit *next;
 };
+
+/** Uncomment this to enable a dlinfo cache on libpulp's side.  It does
+    improve patching time marginally, but requires to be more intrusive
+    on the interposed functions.  */
+
+/*
+#define ENABLE_DLINFO_CACHE
+*/
+
+#ifdef ENABLE_DLINFO_CACHE
+/** Caches dynamic link information required when running `paches` or `trigger`
+    command.  This is maintained for performance reasons.  */
+struct ulp_dlinfo_cache
+{
+  /* Next library cache info.  Must be the first element of this struct so
+     later libpulp versions can add information here without breaking past
+     versions.  */
+  struct ulp_dlinfo_cache *next;
+
+  /** Load bias of component.  */
+  Elf64_Addr bias;
+
+  /** Address of dynsym.  */
+  Elf64_Addr dynsym;
+
+  /** Address of dynstr.  */
+  Elf64_Addr dynstr;
+
+  /** Build ID of library.  */
+  unsigned char buildid[32];
+
+  /** Number of symbols in library.  */
+  int num_symbols;
+
+  /* Sentinel used to mark end of struct.  */
+  uint32_t sentinel;
+};
+#endif
 
 /* Functions present in libcommon, linked agaist both libpulp.so and tools.  */
 const char *get_basename(const char *);

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -24,6 +24,7 @@
     __ulp_get_global_universe;
     __ulp_msg_queue;
     __ulp_metadata_buffer;
+    __ulp_dlinfo_cache;
   local:
     *;
 };

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -394,7 +394,8 @@ check_PROGRAMS = \
   endbr64 \
   manyprocesses \
   dlsym \
-  stress
+  stress \
+  pcqueue
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -511,6 +512,9 @@ stress_SOURCES = stress.c
 stress_LDADD = libstress.la
 stress_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
+pcqueue_SOURCES = pcqueue.c
+pcqueue_LDADD = -lpthread
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -548,7 +552,8 @@ TESTS = \
   endbr64.py \
   dlsym_lock.py \
   stress.py \
-  tempfiles.py
+  tempfiles.py \
+  pcqueue.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/pcqueue.c
+++ b/tests/pcqueue.c
@@ -1,0 +1,48 @@
+/* Include the C file so we have access to the implementation of the pcqueue
+   without having to implement it into a library.  */
+
+#include "../tools/pcqueue.c"
+
+/* How many enqueues/dequeue.  */
+#define NUM_TEST 1000000
+
+static void *
+producer_thread(void *a)
+{
+  long i;
+  producer_consumer_t *pcqueue = a;
+
+  for (i = 0; i < NUM_TEST; i++) {
+    if (producer_consumer_enqueue(pcqueue, (void *)i) != 0) {
+      abort();
+    }
+  }
+
+  return NULL;
+}
+
+int
+main()
+{
+  pthread_t thread;
+  long i;
+
+  producer_consumer_t *pcqueue = producer_consumer_new(8);
+  if (pcqueue == NULL) {
+    printf("Error allocating queue\n");
+    return 1;
+  }
+
+  pthread_create(&thread, NULL, producer_thread, pcqueue);
+
+  for (i = 0; i < NUM_TEST; i++) {
+    void *elem = producer_consumer_dequeue(pcqueue);
+    if ((long)elem != i)
+      abort();
+  }
+
+  pthread_join(thread, NULL);
+  producer_consumer_delete(pcqueue);
+  printf("Pass\n");
+  return 0;
+}

--- a/tests/pcqueue.py
+++ b/tests/pcqueue.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2022 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import testsuite
+
+test = testsuite.spawn('./pcqueue', script=False, timeout=5)
+test.expect('Pass')
+test.close(force=True)

--- a/tests/stress.c
+++ b/tests/stress.c
@@ -4,7 +4,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define NUM_PROCESSES 1000
+#define NUM_PROCESSES 4000
 
 int value(void);
 

--- a/tests/stress.py
+++ b/tests/stress.py
@@ -24,7 +24,7 @@ import subprocess
 child = testsuite.spawn('stress')
 child.expect("Processes launched")
 
-testsuite.childless_livepatch(wildcard='.libs/libstress_livepatch1.so', verbose=False, timeout=60)
+testsuite.childless_livepatch(wildcard='.libs/libstress_livepatch1.so', verbose=False, timeout=120)
 
 child.expect("Processes finished", reject=['returned non-zero'])
 child.close(force=True)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -32,7 +32,8 @@ noinst_HEADERS = \
   post.h \
   messages.h \
   livepatchable.h \
-  elf-extra.h
+  elf-extra.h \
+  pcqueue.h
 
 ulp_SOURCES = \
   ulp.c \
@@ -47,8 +48,9 @@ ulp_SOURCES = \
   introspection.c \
   ptrace.c \
   livepatchable.c \
-  elf-extra.c
-ulp_LDADD = $(top_builddir)/common/libcommon.la -lelf -ldl $(LIBUNWIND_LIBS)
+  elf-extra.c \
+  pcqueue.c
+ulp_LDADD = $(top_builddir)/common/libcommon.la -lelf -lpthread -ldl $(LIBUNWIND_LIBS)
 
 # Ensure access to the include directory
 AM_CFLAGS += -I$(abs_top_srcdir)/include
@@ -57,4 +59,10 @@ if ENABLE_ADDRSAN
 # Add address sanitizer
 AM_CFLAGS += -fsanitize=address,undefined
 AM_LDFLAGS += -fsanitize=address,undefined
+endif
+
+if ENABLE_THREADSAN
+# Add thread sanitizer
+AM_CFLAGS += -fsanitize=thread
+AM_LDFLAGS += -fsanitize=thread
 endif

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -52,6 +52,7 @@ struct arguments
   int verbose;
   int buildid;
   int revert;
+  int disable_threads;
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   int check_stack;
 #endif

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1087,7 +1087,6 @@ set_id_buffer(struct ulp_process *process, unsigned char *patch_id)
 {
   struct ulp_thread *thread;
   Elf64_Addr path_addr;
-  int i;
 
   DEBUG("advertising live patch ID to libpulp.");
 
@@ -1099,11 +1098,9 @@ set_id_buffer(struct ulp_process *process, unsigned char *patch_id)
   thread = process->main_thread;
   path_addr = process->dynobj_libpulp->metadata_buffer;
 
-  for (i = 0; i < 32; i++) {
-    if (write_byte(patch_id[i], thread->tid, path_addr + i)) {
-      WARN("Unable to write id byte %d.", i);
-      return ETARGETHOOK;
-    }
+  if (write_bytes(patch_id, 32, thread->tid, path_addr)) {
+    WARN("Unable to write buildid at address %lx.", path_addr);
+    return ETARGETHOOK;
   }
 
   return 0;
@@ -1143,7 +1140,6 @@ set_string_buffer(struct ulp_process *process, const char *string)
 static int
 set_metadata_buffer(struct ulp_process *process, void *metadata, size_t size)
 {
-  size_t i;
   char *cmetadata = metadata;
 
   struct ulp_thread *thread;
@@ -1157,10 +1153,8 @@ set_metadata_buffer(struct ulp_process *process, void *metadata, size_t size)
   thread = process->main_thread;
   metadata_addr = process->dynobj_libpulp->metadata_buffer;
 
-  for (i = 0; i < size; i++) {
-    if (write_byte(cmetadata[i], thread->tid, metadata_addr + i)) {
-      return EUNKNOWN;
-    }
+  if (write_bytes(cmetadata, size, thread->tid, metadata_addr)) {
+    return EUNKNOWN;
   }
 
   return ENONE;

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -111,6 +111,7 @@ struct ulp_dynobj
   Elf64_Addr msg_queue;
   Elf64_Addr revert_all;
   Elf64_Addr metadata_buffer;
+  Elf64_Addr dlinfo_cache;
   /* end FIXME.  */
 
   struct thread_state *thread_states;
@@ -147,9 +148,6 @@ int dig_load_bias(struct ulp_process *process);
 int parse_main_dynobj(struct ulp_process *process);
 
 int parse_libs_dynobj(struct ulp_process *process);
-
-struct link_map *parse_lib_dynobj(struct ulp_process *process,
-                                  struct link_map *link_map_addr);
 
 struct ulp_dynobj *dynobj_first(struct ulp_process *);
 

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -106,8 +106,19 @@ print_message_buffer(const struct ulp_process *p, bool debug)
     return 1;
   }
 
+  if (attach(p->pid)) {
+    DEBUG("unable to attach to %d to read string.", p->pid);
+    return 1;
+  }
+
   ret = read_memory((void *)&msg_queue, sizeof(struct msg_queue), p->pid,
                     msgq_addr);
+
+  if (detach(p->pid)) {
+    DEBUG("unable to detach from %d.", p->pid);
+    return 1;
+  }
+
   if (ret > 0) {
     WARN("could not read libpulp.so message queue in process %d.", p->pid);
     return 1;

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -168,8 +168,13 @@ is_library_livepatchable(struct ulp_applied_patch *patch,
   }
 
   ElfW(Addr) ehdr_addr = obj->link_map.l_addr;
-
   ElfW(Addr) dynsym_addr = obj->dynsym_addr;
+
+  if (ehdr_addr == 0) {
+    /* If l_addr is zero, it means that there is no load bias.  In that case,
+     * the elf address is on address 0x400000 on x86_64.  */
+    ehdr_addr = 0x400000UL;
+  }
 
   /* Only look the first 64 symbols, else we may take too much time.  */
   int len = MIN(obj->num_symbols, 64);

--- a/tools/patches.h
+++ b/tools/patches.h
@@ -22,8 +22,39 @@
 #ifndef PATCHES_H
 #define PATCHES_H
 
+#include "pcqueue.h"
+
+#include <dirent.h>
+#include <stdbool.h>
+
 struct arguments;
 struct ulp_process;
+
+struct ulp_process_iterator
+{
+  struct ulp_process *now;
+  struct ulp_process *last;
+
+  const char *wildcard;
+  DIR *slashproc;
+  struct dirent *subdir;
+
+  producer_consumer_t *pcqueue;
+};
+
+struct ulp_process *process_list_next(struct ulp_process_iterator *);
+struct ulp_process *process_list_begin(struct ulp_process_iterator *,
+                                       const char *);
+int process_list_end(struct ulp_process_iterator *);
+
+#define FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, wildcard) \
+  struct ulp_process_iterator _it; \
+  for (p = process_list_begin(&_it, wildcard); process_list_end(&_it); \
+       p = process_list_next(&_it))
+
+#define FOR_EACH_ULP_PROCESS(p) FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, NULL)
+
+bool has_libpulp_loaded(int pid);
 
 const char *buildid_to_string(const unsigned char[BUILDID_LEN]);
 

--- a/tools/pcqueue.c
+++ b/tools/pcqueue.c
@@ -1,0 +1,229 @@
+#include "pcqueue.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** @brief Initialize the producer_consumer object.
+ *
+ * This function is for internal use only.  Call `producer_consumer_new` if
+ * you want to create a producer_consumer object.
+ *
+ * @param queue   The queue to initialize
+ * @param n       Maximum number of objects in this queue.
+ * @return        0 if success, anything else if error.
+ */
+static int
+producer_consumer_init(producer_consumer_t *queue, int n)
+{
+  int ret;
+  memset(queue, 0, sizeof(*queue));
+
+  queue->n = n;
+#ifdef MORE_THAN_ONE_ONE
+  ret = pthread_mutex_init(&queue->lock, NULL);
+  if (ret != 0) {
+    return ret;
+  }
+#endif
+  ret = sem_init(&queue->empty, 0, 0);
+  if (ret != 0) {
+    return errno;
+  }
+
+  ret = sem_init(&queue->full, 0, n);
+  if (ret != 0) {
+    return errno;
+  }
+
+  return 0;
+}
+
+/** @brief Create a new producer_consumer object.
+ *
+ * This function allocates memory and initializes a producer_consumer object.
+ * Call `producer_consumer_delete` if you wish to deinitialize and free all
+ * the resources allocated there.
+ *
+ * @param n       Maximum number of objects in this queue.
+ *
+ * @return        Pointer to the created producer_consumer object.
+ */
+producer_consumer_t *
+producer_consumer_new(int n)
+{
+  producer_consumer_t *q;
+  size_t size = sizeof(producer_consumer_t) + n * sizeof(void *);
+
+  q = (producer_consumer_t *)malloc(size);
+
+  if (q == NULL)
+    return NULL;
+
+  if (producer_consumer_init(q, n)) {
+    free(q);
+    q = NULL;
+  }
+  return q;
+}
+
+/** @brief Initialize the producer_consumer object.
+ *
+ * This function is for internal use only.  Call `producer_consumer_delete` if
+ * you want to release a producer_consumer object.
+ *
+ * @param queue   The queue to destroy.
+ *
+ * @return        0 if success, anything else if error.
+ */
+static int
+producer_consumer_destroy(producer_consumer_t *queue)
+{
+  int ret;
+
+#ifdef MORE_THAN_ONE_ONE
+  ret = pthread_mutex_destroy(&queue->lock);
+  if (ret != 0) {
+    return ret;
+  }
+#endif
+
+  ret = sem_destroy(&queue->full);
+  if (ret != 0) {
+    return errno;
+  }
+
+  ret = sem_destroy(&queue->empty);
+  if (ret != 0) {
+    return errno;
+  }
+
+  memset(queue, 0, sizeof(*queue));
+  return 0;
+}
+
+/** @brief Deinitialize and release all resources of `queue`;
+ *
+ * Call this function if you wish to release all resources allocated to a
+ * producer_consumer object.
+ *
+ * @param queue   The queue to destroy.
+ *
+ * @return        0 if success, anything else if error.
+ */
+int
+producer_consumer_delete(producer_consumer_t *queue)
+{
+  int ret = 0;
+  if (queue != NULL) {
+    ret = producer_consumer_destroy(queue);
+    free(queue);
+  }
+
+  return ret;
+}
+
+/** @brief Enqueue an `elem` to the queue.
+ *
+ * Call this function if you wish to enqueue the object `elem` to the queue.
+ *
+ * @param queue   The queue to insert.
+ * @param elem    The element to insert.
+ *
+ * @return        0 if success, anything else if error.
+ */
+int
+producer_consumer_enqueue(producer_consumer_t *queue, void *elem)
+{
+  int ret;
+  /* Block if the queue is full.  */
+  ret = sem_wait(&queue->full);
+  if (ret != 0) {
+    return errno;
+  }
+
+#ifdef MORE_THAN_ONE_ONE
+  /* Acquire lock of queue.  */
+  ret = pthread_mutex_lock(&queue->lock);
+  if (ret != 0) {
+    return ret;
+  }
+#endif
+  /* ----------------------------- */
+
+  queue->elem[queue->head++] = elem;
+
+  /* Wraps around if end of buffer.  */
+  if (queue->head >= queue->n) {
+    queue->head = 0;
+  }
+
+  /* ----------------------------- */
+
+#ifdef MORE_THAN_ONE_ONE
+  /* Release lock of queue.  */
+  ret = pthread_mutex_unlock(&queue->lock);
+  if (ret != 0) {
+    return ret;
+  }
+#endif
+
+  /* Alert other threads that we inserted something.  */
+  ret = sem_post(&queue->empty);
+  if (ret != 0) {
+    return errno;
+  }
+
+  return 0;
+}
+
+/** @brief Dequeue an element from producer_consumer `queue`.
+ *
+ * Call this function if you wish to dequeue an element from the queue.
+ *
+ * @param queue   The queue to get an element from.
+ * @return        The dequeued element.
+ */
+void *
+producer_consumer_dequeue(producer_consumer_t *queue)
+{
+  void *ret;
+
+  /* Block if the queue is empty.  */
+  if (sem_wait(&queue->empty) != 0) {
+    return NULL;
+  }
+
+#ifdef MORE_THAN_ONE_ONE
+  /* Acquire lock of queue.  */
+  if (pthread_mutex_lock(&queue->lock) != 0) {
+    return NULL;
+  }
+#endif
+
+  /* ----------------------------- */
+
+  ret = queue->elem[queue->tail++];
+
+  /* Wraps around if end of buffer.  */
+  if (queue->tail >= queue->n) {
+    queue->tail = 0;
+  }
+
+  /* ----------------------------- */
+
+#ifdef MORE_THAN_ONE_ONE
+  /* Release lock of queue.  */
+  if (pthread_mutex_unlock(&queue->lock) != 0) {
+    return NULL;
+  }
+#endif
+
+  /* Alert other threads that we inserted something.  */
+  if (sem_post(&queue->full) != 0) {
+    return NULL;
+  }
+
+  return ret;
+}

--- a/tools/pcqueue.h
+++ b/tools/pcqueue.h
@@ -1,0 +1,55 @@
+#ifndef PCQUEUE_H
+#define PCQUEUE_H
+
+#include <pthread.h>
+#include <semaphore.h>
+
+/* Uncoment this if the producer_consumer queue should support multiple
+   producers and consumers.  */
+/* #define MORE_THAN_ONE_ONE  */
+
+/** A producer-consumer queue.  This structure creates a channel in which
+    two threads can communicate, one by enqueuing elements and another by
+    dequeuing elements.  */
+struct producer_consumer
+{
+  /** Maximum number of elements in this queue.  */
+  int n;
+
+  /** Position of the last inserted element.*/
+  int head;
+
+  /** Position of the oldest element in the queue.  */
+  int tail;
+
+  /** Semaphore that will block any attempt of dequeuing an element if the
+      queue is empty.  */
+  sem_t empty;
+
+  /** Semaphore that will block any attempt of enqueuing an element if the
+      queue is full.  */
+  sem_t full;
+#ifdef MORE_THAN_ONE_ONE
+  /** Lock for head & tail.  This is unnecessary if there is only one producer
+      and one consumer.  If you wish to support many producers and many
+      consumers, define MORE_THAN_ONE_ONE.  */
+  pthread_mutex_t lock;
+#endif
+
+  /** The queue buffer.  The 0 array element denotes where it starts, but it is
+      allocated in `producer_consumer_new`.  */
+  void *elem[0];
+};
+
+/** Typedef for a shorthand of struct producer_consumer.  */
+typedef struct producer_consumer producer_consumer_t;
+
+producer_consumer_t *producer_consumer_new(int n);
+
+int producer_consumer_delete(producer_consumer_t *queue);
+
+int producer_consumer_enqueue(producer_consumer_t *queue, void *elem);
+
+void *producer_consumer_dequeue(producer_consumer_t *queue);
+
+#endif // PCQUEUE_H

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -151,17 +151,9 @@ write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr)
  * Returns 0 if the operation succeeds; 1 otherwise.
  */
 int
-write_string(const char *buffer, int pid, Elf64_Addr addr, int size)
+write_string(const char *buffer, int pid, Elf64_Addr addr)
 {
-  size_t len = strlen(buffer);
-
-  if (len > (unsigned)size) {
-    len = size;
-  }
-
-  /* Invalidate tlb because we are commiting changes to memory.  */
-  tlb = 0;
-
+  size_t len = strlen(buffer) + 1;
   return write_bytes(buffer, len, pid, addr);
 }
 

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -68,6 +68,14 @@ ulp_ptrace(enum __ptrace_request request, pid_t pid, void *addr, void *data)
   time_t t0, t1;
   long ret;
 
+  /* Unroll first iteration to avoid calls to time if it succeeds on first try.
+   */
+  errno = 0;
+  ret = ptrace(request, pid, addr, data);
+  if (!(errno == EBUSY || errno == EPERM)) {
+    return ret;
+  }
+
   t0 = time(NULL);
   do {
     errno = 0;

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -221,11 +221,6 @@ read_memory(char *byte, size_t len, int pid, Elf64_Addr addr)
 
   long *word = (long *)byte;
 
-  if (attach(pid)) {
-    DEBUG("unable to attach to %d to read data.\n", pid);
-    return 1;
-  };
-
   /* Read as much as we can using longs, since it has larger bandwith when
      compared to bytes.  */
   for (i = 0; i < len_word; i++) {
@@ -242,11 +237,6 @@ read_memory(char *byte, size_t len, int pid, Elf64_Addr addr)
       return 1;
   }
 
-  if (detach(pid)) {
-    DEBUG("unable to detach from %d after reading data.\n", pid);
-    return 1;
-  };
-
   return 0;
 }
 
@@ -256,11 +246,6 @@ read_string(char **buffer, int pid, Elf64_Addr addr)
   int i = 0;
   char *string;
   int buffer_len;
-
-  if (attach(pid)) {
-    DEBUG("unable to attach to %d to read string.", pid);
-    return 1;
-  }
 
   buffer_len = 32;
   string = (char *)malloc(buffer_len);
@@ -279,11 +264,6 @@ read_string(char **buffer, int pid, Elf64_Addr addr)
     }
   }
   while (string[i++] != '\0');
-
-  if (detach(pid)) {
-    DEBUG("unable to detach from %d after reading string.", pid);
-    return 1;
-  };
 
   *buffer = string;
   return 0;

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -35,9 +35,7 @@ int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
 int write_string(const char *buffer, int pid, Elf64_Addr addr);
 
-int read_byte(char *byte, int pid, Elf64_Addr addr);
-
-int read_memory(char *byte, size_t len, int pid, Elf64_Addr addr);
+int read_memory(void *byte, size_t len, int pid, Elf64_Addr addr);
 
 int read_string(char **buffer, int pid, Elf64_Addr addr);
 

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -37,6 +37,8 @@ int write_string(const char *buffer, int pid, Elf64_Addr addr);
 
 int read_memory(void *byte, size_t len, int pid, Elf64_Addr addr);
 
+int read_string_allocated(void *buffer, size_t n, int pid, Elf64_Addr addr);
+
 int read_string(char **buffer, int pid, Elf64_Addr addr);
 
 /* Signaling functions */

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -33,7 +33,7 @@
 
 int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
-int write_string(const char *buffer, int pid, Elf64_Addr addr, int length);
+int write_string(const char *buffer, int pid, Elf64_Addr addr);
 
 int read_byte(char *byte, int pid, Elf64_Addr addr);
 

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -30,7 +30,8 @@
 #include "ulp_common.h"
 
 /* Memory read/write helper functions */
-int write_byte(char byte, int pid, Elf64_Addr addr);
+
+int write_bytes(const void *buf, size_t n, int pid, Elf64_Addr addr);
 
 int write_string(const char *buffer, int pid, Elf64_Addr addr, int length);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -230,6 +230,7 @@ trigger_many_ulps(struct ulp_process *p, int retries,
   char buffer[ULP_PATH_LEN];
 
   int ret = 0, r;
+  int ulp_folder_path_len = strlen(ulp_folder_path);
 
   if (!directory) {
     FATAL("Unable to open directory: %s", ulp_folder_path);
@@ -237,18 +238,23 @@ trigger_many_ulps(struct ulp_process *p, int retries,
     goto wildcard_clean;
   }
 
+  strcpy(buffer, ulp_folder_path);
+  strcat(buffer, "/");
+  ulp_folder_path_len += 1;
+
   while ((entry = readdir(directory)) != NULL) {
     struct stat stbuf;
     int bytes;
-    memset(buffer, '\0', ULP_PATH_LEN);
 
-    bytes = snprintf(buffer, ULP_PATH_LEN, "%s/%s", ulp_folder_path,
-                     entry->d_name);
-    if (bytes == ULP_PATH_LEN) {
+    bytes = ulp_folder_path_len + strlen(entry->d_name);
+
+    if (bytes >= ULP_PATH_LEN) {
       WARN("Path to %s is larger than %d bytes. Skipping...\n", entry->d_name,
            ULP_PATH_LEN);
       continue;
     }
+
+    strcpy(buffer + ulp_folder_path_len, entry->d_name);
 
     if (stat(buffer, &stbuf)) {
       WARN("Error retrieving stats for %s. Skiping...\n", buffer);

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -124,6 +124,7 @@ static const char doc[] =
 #define ULP_OP_REVERT 257
 #define ULP_OP_COLOR 258
 #define ULP_OP_TIMEOUT 259
+#define ULP_OP_DISABLE_THREADING 260
 
 static struct argp_option options[] = {
   { 0, 0, 0, 0, "Options:", 0 },
@@ -131,6 +132,8 @@ static struct argp_option options[] = {
   { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
   { 0, 0, 0, 0, "patches, check & trigger commands only:", 0 },
   { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+  { "disable-threading", ULP_OP_DISABLE_THREADING, 0, 0,
+    "Do not launch additional threads", 0 },
   { 0, 0, 0, 0, "dump & patches command only:", 0 },
   { "buildid", 'b', 0, 0, "Print the build id", 0 },
   { 0, 0, 0, 0, "trigger command only:", 0 },
@@ -319,6 +322,10 @@ parser(int key, char *arg, struct argp_state *state)
     case ULP_OP_REVERT:
       arguments->revert = 1;
       break;
+    case ULP_OP_DISABLE_THREADING:
+      arguments->disable_threads = 1;
+      break;
+
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
     case 'c':
       arguments->check_stack = 1;


### PR DESCRIPTION
This PR refactors code in tools side so that livepatching is faster on a large number of processes.

Such changes include:
  - Replace sprintf with strcpy to concatenate strings.
  - Limit the number of symbols to check if a library is livepatchable.
  - Reduce the amount of target processes reads.
  - Add an optional cache to speedup symbol discovery.
  - Replace ptrace with process_vm_writev/readv when possible.
  - Reduce the number of attach/detach.
  - Avoid wildcard matching if input is not a wildcard.
  - Discover libpulp symbols in a separate thread.
  - Add support to thread sanitizer.
  
  That changes reduces the trigger time on `stress` test (4000 processes) from 26.8s to 4.3s on an Intel Xeon E5 2670-v3.