### PR TITLE
Add -R --root=PREFIX option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([libpulp],[0.2.5],[noreply@suse.com])
+AC_INIT([libpulp],[0.2.6],[noreply@suse.com])
 
 # Keep most generated files under the config directory.
 AC_CONFIG_AUX_DIR([config])

--- a/man/ulp.1
+++ b/man/ulp.1
@@ -265,6 +265,10 @@ Display a brief usage message.
 .B -V --version
 Print program version and exit.
 .TP
+.B -R --root=PREFIX
+Append PREFIX to the path to the livepatch .so file when it is send to the
+target process. This is useful if ulp is running inside a chroot.
+.TP
 .SH EXIT STATUS
 .B ulp packer
 exits 0 on success and 1 on error.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -172,6 +172,14 @@ libendbr64_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libendbr64.post
 
+check_LTLIBRARIES += libprefix.la
+
+libprefix_la_SOURCES = libprefix.c
+libprefix_la_CFLAGS = $(TARGET_CFLAGS)
+libprefix_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libprefix.post
+
 # Target libraries to test static data access
 check_LTLIBRARIES += libmanyprocesses.la
 
@@ -213,6 +221,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libbuildid_livepatch1.la \
                      libprocess_access_livepatch1.la \
                      libendbr64_livepatch1.la \
+                     libprefix_livepatch1.la \
                      libmanyprocesses_livepatch1.la \
                      libstress_livepatch1.la \
                      libcomments_livepatch1.la
@@ -280,6 +289,9 @@ libbuildid_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libendbr64_livepatch1_la_SOURCES = libhundreds_livepatch1.c
 libendbr64_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libprefix_livepatch1_la_SOURCES = libhundreds_livepatch1.c
+libprefix_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 libprocess_access_livepatch1_la_SOURCES = process_access_livepatch1.c
 libprocess_access_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
@@ -335,6 +347,8 @@ METADATA = \
   libmanyprocesses_livepatch1.ulp \
   libendbr64_livepatch1.dsc \
   libendbr64_livepatch1.ulp \
+  libprefix_livepatch1.dsc \
+  libprefix_livepatch1.ulp \
   libprocess_livepatch1.dsc \
   libprocess_livepatch1.ulp \
   libprocess_access_livepatch1.dsc \
@@ -365,6 +379,7 @@ EXTRA_DIST = \
   libtls_livepatch1.in \
   libbuildid_livepatch1.in \
   libendbr64_livepatch1.in \
+  libprefix_livepatch1.in \
   libmanyprocesses_livepatch1.in \
   libprocess_livepatch1.in \
   libprocess_access_livepatch1.in \
@@ -399,6 +414,7 @@ check_PROGRAMS = \
   buildid \
   process_access \
   endbr64 \
+  prefix \
   manyprocesses \
   dlsym \
   stress \
@@ -416,6 +432,10 @@ numserv_bsymbolic_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 endbr64_SOURCES = endbr64.c
 endbr64_LDADD = libdozens.la libendbr64.la
 endbr64_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+prefix_SOURCES = prefix.c
+prefix_LDADD = libdozens.la libprefix.la
+prefix_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 parameters_SOURCES = parameters.c
 parameters_LDADD = libparameters.la
@@ -562,6 +582,7 @@ TESTS = \
   process_access.py \
   manyprocesses.py \
   endbr64.py \
+  prefix.py \
   dlsym_lock.py \
   stress.py \
   tempfiles.py \

--- a/tests/libprefix.c
+++ b/tests/libprefix.c
@@ -1,7 +1,7 @@
 /*
  *  libpulp - User-space Livepatching Library
  *
- *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
  *
  *  This file is part of libpulp.
  *
@@ -19,45 +19,8 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
-
-#include "config.h"
-
-#define ARGS_MAX 1
-
-typedef enum
+int
+hundred(void)
 {
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-  ULP_MESSAGES,
-  ULP_LIVEPATCHABLE,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  const char *process_wildcard;
-  const char *prefix;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid;
-  int revert;
-  int disable_threads;
-  int recursive;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
-
-#endif
+  return 100;
+}

--- a/tests/libprefix_livepatch1.in
+++ b/tests/libprefix_livepatch1.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libprefix_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libprefix.so.0
+hundred:two_hundreds

--- a/tests/prefix.c
+++ b/tests/prefix.c
@@ -1,7 +1,7 @@
 /*
  *  libpulp - User-space Livepatching Library
  *
- *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *  Copyright (C) 2020-2022 SUSE Software Solutions GmbH
  *
  *  This file is part of libpulp.
  *
@@ -19,45 +19,37 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
 
-#include "config.h"
+#include <dozens.h>
+#include <hundreds.h>
 
-#define ARGS_MAX 1
-
-typedef enum
+int
+main(void)
 {
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-  ULP_MESSAGES,
-  ULP_LIVEPATCHABLE,
-} command_t;
+  char input[64];
 
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  const char *process_wildcard;
-  const char *prefix;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid;
-  int revert;
-  int disable_threads;
-  int recursive;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
+  printf("Waiting for input.\n");
+  while (1) {
+    if (scanf("%s", input) == EOF) {
+      if (errno) {
+        perror("numserv");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    if (strncmp(input, "dozen", strlen("dozen")) == 0)
+      printf("%d\n", dozen());
+    if (strncmp(input, "hundred", strlen("hundred")) == 0)
+      printf("%d\n", hundred());
+    if (strncmp(input, "quit", strlen("quit")) == 0) {
+      printf("Quitting.\n");
+      return 0;
+    }
+  }
 
-#endif
+  return 1;
+}

--- a/tests/prefix.py
+++ b/tests/prefix.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This test checks if passing the -R option to trigger with a silly
+# prefix causes the patching to fail on libpulp.so side.  This is
+# useful if ulp runs in a chroot.
+
+import testsuite
+import re
+
+child = testsuite.spawn('prefix')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('.libs/libprefix_livepatch1.so', prefix="/silly-prefix/", sanity=False)
+
+msgs = child.get_libpulp_messages()
+if re.search(r'Unable to load shared object /silly-prefix/.*/.libs/libprefix_livepatch1.so', msgs):
+  error = 0
+else:
+  error = 1
+
+child.close(force=True)
+exit(error)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -234,7 +234,7 @@ class spawn(pexpect.spawn):
   # output for more information).
   def livepatch(self, filename=None, timeout=10, retries=1,
                 verbose=True, quiet=False, revert=False, revert_lib=None,
-                sanity=True):
+                sanity=True, prefix=None):
 
     # Check sanity of command-line arguments
     if sanity is True:
@@ -259,6 +259,9 @@ class spawn(pexpect.spawn):
     if retries > 1:
       command.append('-r')
       command.append(str(retries))
+    if prefix is not None:
+      command.append('-R')
+      command.append(str(prefix))
 
     # Apply the live patch and check for common errors
     try:

--- a/tools/check.c
+++ b/tools/check.c
@@ -57,7 +57,8 @@ run_check(struct arguments *arguments)
 
   container = arguments->args[0];
 
-  livepatch_size = extract_ulp_from_so_to_mem(container, false, &livepatch);
+  livepatch_size =
+      extract_ulp_from_so_to_mem(container, false, &livepatch, NULL);
 
   if (!livepatch) {
     WARN("error extracting .ulp section from %s", container);
@@ -87,7 +88,7 @@ run_check(struct arguments *arguments)
     goto ulp_process_clean;
   }
 
-  if (check_patch_sanity(target)) {
+  if (check_patch_sanity(target, NULL)) {
     WARN("error checking live patch sanity.");
     ret = -1;
     goto ulp_process_clean;

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -104,7 +104,7 @@ run_dump(struct arguments *arguments)
   bool revert = arguments->revert;
 
   livepatch_size =
-      extract_ulp_from_so_to_mem(arguments->args[0], revert, &livepatch);
+      extract_ulp_from_so_to_mem(arguments->args[0], revert, &livepatch, NULL);
   if (!livepatch) {
     WARN("Unable to extract metadata file from %s", arguments->args[0]);
     return 1;

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -173,13 +173,13 @@ int read_global_universe(struct ulp_process *process);
 
 char *extract_ulp_from_so_to_disk(const char *, bool);
 
-size_t extract_ulp_from_so_to_mem(const char *, bool, char **);
+size_t extract_ulp_from_so_to_mem(const char *, bool, char **, const char *);
 
 int load_patch_info_from_disk(const char *livepatch);
 
 int load_patch_info_from_mem(void *src, size_t size);
 
-int check_patch_sanity();
+int check_patch_sanity(struct ulp_process *, const char *);
 
 struct ulp_applied_patch *ulp_read_state(struct ulp_process *);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -44,6 +44,7 @@
 #include "ulp_common.h"
 
 static bool recursive_mode;
+static const char *prefix = NULL;
 
 /** @brief Apply a single live patch to one process.
  *
@@ -76,7 +77,7 @@ trigger_one_process(struct ulp_process *target, int retries,
   /* Extract the livepatch metadata from .so file.  */
   if (container_path) {
     livepatch_size =
-        extract_ulp_from_so_to_mem(container_path, revert, &livepatch);
+        extract_ulp_from_so_to_mem(container_path, revert, &livepatch, prefix);
     if (livepatch == NULL || livepatch_size == 0) {
       ret = ENOMETA;
       goto metadata_clean;
@@ -92,7 +93,7 @@ trigger_one_process(struct ulp_process *target, int retries,
   }
 
   if (livepatch) {
-    ret = check_patch_sanity(target);
+    ret = check_patch_sanity(target, prefix);
     if (ret) {
       /* Sanity may fail because the patch should not be applied to this
          process.  */
@@ -596,6 +597,9 @@ run_trigger(struct arguments *arguments)
   bool revert = (arguments->revert > 0);
   pid_t pid = 0;
   int ret;
+
+  /* Set global static prefix variable.  */
+  prefix = arguments->prefix;
 
   if (isnumber(process_wildcard))
     pid = atoi(process_wildcard);

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -144,6 +144,8 @@ static struct argp_option options[] = {
   { "timeout", ULP_OP_TIMEOUT, "t", 0,
     "Set trigger timeout to t seconds (default 200s)", 0 },
   { "recursive", ULP_OP_RECURSIVE, 0, 0, "Search for patches recursively", 0 },
+  { "root", 'R', "PREFIX", 0,
+    "Append prefix to livepatch path when passing it to target process", 0 },
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   { "check-stack", 'c', 0, 0, "Check the call stack before live patching", 0 },
 #endif
@@ -318,6 +320,9 @@ parser(int key, char *arg, struct argp_state *state)
         argp_error(state,
                    "The argument to '-r' must be greater than zero; got %d.",
                    arguments->retries);
+      break;
+    case 'R':
+      arguments->prefix = arg;
       break;
     case ULP_OP_REVERT_ALL:
       arguments->library = get_basename(arg);


### PR DESCRIPTION
When `ulp` tool runs in a chroot'ed directory, the `realpath` function will return the path to the root from the chroot, not the path from the true root.  This commit introduces the --root=PREFIX options which appends PREFIX to the path to the patch file right before sending it to the target process, providing a way to workaround this chroot problem.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>