### PR TITLE
Add support for target library dumps

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,7 +39,7 @@ jobs:
       run: zypper -n install autoconf-archive libelf-devel
         python3-pexpect python3-psutil libunwind-devel
         git gcc gcc-c++ clang libtool make dash valgrind gzip
-        findutils
+        findutils libjson-c-devel
     - uses: actions/checkout@v2
     - name: bootstrap
       run: ./bootstrap

--- a/Makefile.common
+++ b/Makefile.common
@@ -22,6 +22,7 @@ ULP = $(top_builddir)/tools/ulp
 ULP_POST = $(ULP) post
 ULP_PACKER = $(ULP) packer
 ULP_REVERSE = $(ULP) reverse
+ULP_EXTRACT = $(ULP) extract
 
 # Build and link requirements for live-patchable (target) libraries.
 TARGET_CFLAGS = \
@@ -46,8 +47,13 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 # ulp_post, which replaces single-byte with multi-byte nops. Files with
 # .post extension track whether the respective libraries have already
 # been post-processed.
+#
+# Since we also support to specify the target library as a dump of the
+# relevant informations (name, symbols, build id), we also have extra
+# logic to generate such dumps (JSON file).
 .libs/lib%.post: lib%.la
-	$(ULP_POST) .libs/lib$*.so
+	$(ULP_POST) .libs/lib$*.so.0
+	$(ULP_EXTRACT) .libs/lib$*.so.0 -o .libs/lib$*.so.0.json
 	touch $@
 
 # These rules cause the livepatch metadata to be built. The .ulp and
@@ -60,7 +66,10 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 	$(top_srcdir)/tests/offsets.py $*.tmp $@
 	rm -f $*.tmp
 
+# This rule build the .ulp file, which at some point were used to hold
+# the compiled metadata description. Today it is directly integrated
+# into the .so file which holds the livepatch code, within the .ulp
+# and .ulp.rev section.
 %.ulp: %.dsc $(check_LTLIBRARIES)
-	echo .libs/$(basename $<).so
 	$(ULP_PACKER) $< #-o $@
 	echo Maintained here for legacy reasons > $@

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([libpulp],[0.2.6],[noreply@suse.com])
+AC_INIT([libpulp],[0.2.7],[noreply@suse.com])
 
 # Keep most generated files under the config directory.
 AC_CONFIG_AUX_DIR([config])

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ AC_CONFIG_FILES([Makefile
 		 tests/Makefile
 		 tools/Makefile
 		 common/Makefile
-		 docs/Makefile])
+		 docs/Makefile
+		 scripts/Makefile])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,9 @@ AS_IF([test "x$fcf_protection" == "xyes"],
 AC_CHECK_HEADER([gelf.h],,
 AC_MSG_ERROR([Libelf development files are missing.]))
 
+AC_CHECK_HEADER([json-c/json.h],,
+AC_MSG_ERROR([json-c development files are missing.]))
+
 # Python and python's pexpect are required to run the tests.
 AM_PATH_PYTHON([3])
 AX_PYTHON_MODULE([pexpect], [fatal])

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -254,7 +254,7 @@ dl_find_symbol(struct dl_phdr_info *info, size_t size, void *data)
 
     sym = get_symbol_by_name(dynsym, dynstr, num_symbols, args->symbol);
     if (sym)
-      args->symbol_addr = (void *)(info->dlpi_addr + sym->st_value);
+      args->symbol_addr = (void *)(sym->st_value);
 
     args->bias_addr = info->dlpi_addr;
     /* Alert dl_iterate_phdr that we are finished.  */
@@ -291,11 +291,16 @@ get_loaded_symbol_addr(const char *library, const char *symbol,
   dl_iterate_phdr(dl_find_symbol, &arg);
 
   if (old_faddr != NULL && arg.symbol_addr != old_faddr) {
-    WARN("Symbol requested not found in .dymsym. Using address from .ulp");
+    WARN("Symbol requested not found in .dynsym. Using address from .ulp");
     return arg.bias_addr + old_faddr;
   }
 
-  return arg.symbol_addr;
+  if (arg.symbol_addr == NULL) {
+    /* Symbol not found.  */
+    return NULL;
+  }
+
+  return arg.bias_addr + arg.symbol_addr;
 }
 
 static int

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -104,7 +104,7 @@ revert_all_patches_from_lib(const char *lib_name)
 
   const char *lib_basename = get_basename(lib_name);
 
-  int ret = 0;
+  int ret = ENOTARGETLIB;
 
   /* Paranoid: check if the path buffer didn't overflow.  */
   if ((ptrdiff_t)(lib_basename - lib_name) >= ULP_PATH_LEN) {
@@ -117,10 +117,12 @@ revert_all_patches_from_lib(const char *lib_name)
     if (!strncmp(lib_basename, patch->lib_name, ULP_PATH_LEN)) {
       ret = ulp_can_revert_patch(patch->patch_id);
       if (ret) {
-        break;
+        continue;
       }
 
       ret = ulp_revert_patch(patch->patch_id);
+      if (ret)
+        return ret;
     }
 
     patch = next;

--- a/man/ulp.1
+++ b/man/ulp.1
@@ -484,3 +484,30 @@ Messages are output to stdout.
 .TP
 .B ulp messages
 exits 0 on success, anything else on error.
+
+.\"-------------------------------------------
+
+.SH EXTRACT
+.TP
+.SH NAME
+ulp extract \- Extract the relevant content from a livepatchable library
+.TP
+.SH SYNOPSIS
+.TP
+.B ulp extract
+.I livepatchable_library
+-o
+.I output_file
+.TP
+.SH DESCRIPTION
+.TP
+Extract the relevant content from
+.I livepatchable_library
+such as the library name, buildid, and symbols in the library; and write those
+informations into a JSON file specified by
+.I output_file.
+.PP
+.TP
+.SH EXIT STATUS
+.TP
+exits 0 on success, anything else on error.

--- a/man/ulp.1
+++ b/man/ulp.1
@@ -382,6 +382,11 @@ aborts the live patching operation; on the other hand, if no threads are within
 the target library, the live patch can be applied with additional consistency
 guarantees.
 .TP
+.B --revert-all=LIB
+Before applying the live patch to the target process, revert all livepatches
+applied to the library LIB. If LIB=target, then all patches to the target
+library of the livepatch will be removed.
+.TP
 .B -q, --quiet
 Do not produce any output.
 .TP

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,6 +1,6 @@
 #   libpulp - User-space Livepatching Library
 #
-#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#   Copyright (C) 2020-2023 SUSE Software Solutions GmbH
 #
 #   This file is part of libpulp.
 #
@@ -17,8 +17,4 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-ACLOCAL_AMFLAGS = -I config
-
-SUBDIRS = include common lib man tools tests docs scripts
-
-EXTRA_DIST = LICENSE README.md
+dist_bin_SCRIPTS=setup_package.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -574,6 +574,8 @@ TESTS = \
   libpulp_messages.py \
   relative_path.py \
   revert_all.py \
+  revert_all_target1.py \
+  revert_all_target2.py \
   revert_and_patch.py \
   process.py \
   process_revert.py \

--- a/tests/libaccess_livepatch1.in
+++ b/tests/libaccess_livepatch1.in
@@ -1,4 +1,4 @@
 __ABS_BUILDDIR__/.libs/libaccess_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libaccess.so.0
+@__ABS_BUILDDIR__/.libs/libaccess.so.0.json
 banner_set:new_banner_set
 #banner:ulpr_banner:__TARGET_OFFSET__:__PATCH_OFFSET__

--- a/tests/libaccess_livepatch2.in
+++ b/tests/libaccess_livepatch2.in
@@ -1,4 +1,4 @@
 __ABS_BUILDDIR__/.libs/libaccess_livepatch2.so
-@__ABS_BUILDDIR__/.libs/libaccess.so.0
+@__ABS_BUILDDIR__/.libs/libaccess.so.0.json
 banner_set:new_banner_set
 #banner:ulpr_banner

--- a/tests/libaddress_livepatch1.in
+++ b/tests/libaddress_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libaddress_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libaddress.so.0
+@__ABS_BUILDDIR__/.libs/libaddress.so.0.json
 get_address:new_get_address

--- a/tests/libblocked_livepatch1.in
+++ b/tests/libblocked_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libblocked_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libblocked.so.0
+@__ABS_BUILDDIR__/.libs/libblocked.so.0.json
 hello:olleh

--- a/tests/libcontract_livepatch1.in
+++ b/tests/libcontract_livepatch1.in
@@ -1,5 +1,5 @@
 __ABS_BUILDDIR__/.libs/libcontract_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libcontract.so.0
+@__ABS_BUILDDIR__/.libs/libcontract.so.0.json
 print:new_print
 fna:new_fna
 fnb:new_fnb

--- a/tests/libdozens_bsymbolic_livepatch1.in
+++ b/tests/libdozens_bsymbolic_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libdozens_bsymbolic_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libdozens_bsymbolic.so.0
+@__ABS_BUILDDIR__/.libs/libdozens_bsymbolic.so.0.json
 dozen:baker_dozen

--- a/tests/libdozens_livepatch1.in
+++ b/tests/libdozens_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libdozens_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libdozens.so.0
+@__ABS_BUILDDIR__/.libs/libdozens.so.0.json
 dozen:baker_dozen

--- a/tests/libdozens_livepatch99.in
+++ b/tests/libdozens_livepatch99.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libdozens_livepatch99.so
-@__ABS_BUILDDIR__/.libs/libdozens.so.0
+@__ABS_BUILDDIR__/.libs/libdozens.so.0.json
 hidden_dozen:hidden_baker_dozen

--- a/tests/libendbr64_livepatch1.in
+++ b/tests/libendbr64_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libendbr64_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libendbr64.so.0
+@__ABS_BUILDDIR__/.libs/libendbr64.so.0.json
 hundred:two_hundreds

--- a/tests/libhundreds_livepatch1.in
+++ b/tests/libhundreds_livepatch1.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libhundreds_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libhundreds.so.0
+@__ABS_BUILDDIR__/.libs/libhundreds.so.0.json
 hundred:two_hundreds

--- a/tests/libhundreds_livepatch2.in
+++ b/tests/libhundreds_livepatch2.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libhundreds_livepatch2.so
-@__ABS_BUILDDIR__/.libs/libhundreds.so.0
+@__ABS_BUILDDIR__/.libs/libhundreds.so.0.json
 hundred:three_hundreds

--- a/tests/libhundreds_livepatch3.in
+++ b/tests/libhundreds_livepatch3.in
@@ -1,3 +1,3 @@
 __ABS_BUILDDIR__/.libs/libhundreds_livepatch3.so
-@__ABS_BUILDDIR__/.libs/libhundreds.so.0
+@__ABS_BUILDDIR__/.libs/libhundreds.so.0.json
 hundred:four_hundreds

--- a/tests/libstress.c
+++ b/tests/libstress.c
@@ -1,4 +1,5 @@
-int value(void)
+int
+value(void)
 {
   return 1;
 }

--- a/tests/libtls_livepatch1.in
+++ b/tests/libtls_livepatch1.in
@@ -1,4 +1,4 @@
 __ABS_BUILDDIR__/.libs/libtls_livepatch1.so
-@__ABS_BUILDDIR__/.libs/libtls.so.0
+@__ABS_BUILDDIR__/.libs/libtls.so.0.json
 banner_set:new_banner_set
 #%banner:ti:__TARGET_OFFSET__:__PATCH_OFFSET__

--- a/tests/offsets.py
+++ b/tests/offsets.py
@@ -35,6 +35,7 @@ patch = patch.rstrip('\n')
 # which always starts with '@'
 target = ifile.readline()
 target = target.rstrip('\n')
+target = target.rstrip('.json')
 target = target.lstrip('@')
 
 # Rewind the input file

--- a/tests/revert_all_target1.py
+++ b/tests/revert_all_target1.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('.libs/libhundreds_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.livepatch('.libs/libhundreds_livepatch2.so', revert_lib="target")
+
+child.sendline('hundred')
+child.expect('300', reject=['100', '200'])
+
+child.livepatch('.libs/libhundreds_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject=['100', '300'])
+
+child.close(force=True)
+exit(0)

--- a/tests/revert_all_target2.py
+++ b/tests/revert_all_target2.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('hundred')
+child.expect('100')
+
+child.livepatch('.libs/libhundreds_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.livepatch(revert_lib="target", sanity=False)
+
+child.sendline('hundred')
+child.expect('200', reject='100')
+
+child.close(force=True)
+exit(0)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -33,7 +33,8 @@ noinst_HEADERS = \
   messages.h \
   livepatchable.h \
   elf-extra.h \
-  pcqueue.h
+  pcqueue.h \
+  extract.h
 
 ulp_SOURCES = \
   ulp.c \
@@ -49,8 +50,9 @@ ulp_SOURCES = \
   ptrace.c \
   livepatchable.c \
   elf-extra.c \
-  pcqueue.c
-ulp_LDADD = $(top_builddir)/common/libcommon.la -lelf -lpthread -ldl $(LIBUNWIND_LIBS)
+  pcqueue.c \
+  extract.c
+ulp_LDADD = $(top_builddir)/common/libcommon.la -lelf -ljson-c -lpthread -ldl $(LIBUNWIND_LIBS)
 
 # Ensure access to the include directory
 AM_CFLAGS += -I$(abs_top_srcdir)/include

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -37,6 +37,7 @@ typedef enum
   ULP_POST,
   ULP_MESSAGES,
   ULP_LIVEPATCHABLE,
+  ULP_EXTRACT,
 } command_t;
 
 struct arguments

--- a/tools/extract.c
+++ b/tools/extract.c
@@ -1,0 +1,609 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2023 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <json-c/json.h>
+
+#include "arguments.h"
+#include "config.h"
+#include "elf-extra.h"
+#include "terminal_colors.h"
+#include "ulp_common.h"
+#include "elf-extra.h"
+#include "packer.h"
+#include "extract.h"
+
+/** @brief Convert a string to a build id.
+ *
+ * This function converts the buildid in string form provided by str
+ * and write its buildid form in the buffer provided by `buf`.
+ *
+ * @param buf     Buffer to write to.
+ * @param str     Input string.
+ *
+ * @return        EINVAL if string is invalid, 0 otherwise.
+ */
+static int
+str_to_buildid(unsigned char buf[BUILDID_LEN], const char *str)
+{
+  int i;
+
+  if (strlen(str) < BUILDID_LEN) {
+    /* Invalid buildid given.  */
+    return EINVAL;
+  }
+
+  for (i = 0; i < BUILDID_LEN; i++) {
+    unsigned val;
+    sscanf(&str[2*i], "%02x", &val);
+
+    buf[i] = (unsigned char) val;
+  }
+
+  return 0;
+}
+
+/* clang-format off */
+
+/** Table mapping ST_TYPE values to its name.  */
+static const char *const st_type_names[] = {
+  /*  0 = */ "STT_NOTYPE",
+  /*  1 = */ "STT_OBJECT",
+  /*  2 = */ "STT_FUNC",
+  /*  3 = */ "STT_SECTION",
+  /*  4 = */ "STT_FILE",
+  /*  5 = */ "STT_COMMON",
+  /*  6 = */ "STT_TLS",
+  /*  7 = */ "STT_NUM",
+  /*  8 = */ NULL,
+  /*  9 = */ NULL,
+  /* 10 = */ "STT_GNU_IFUNC",
+  /* 11 = */ NULL,
+  /* 12 = */ "STT_HIOS",
+  /* 13 = */ "STT_LOPROC",
+  /* 14 = */ NULL,
+  /* 15 = */ "STT_HIPROC",
+};
+
+/** Table mapping ST_BIND values to its name.  */
+static const char *const st_bind_names[] = {
+  /*  0 = */ "STB_LOCAL",
+  /*  1 = */ "STB_GLOBAL",
+  /*  2 = */ "STB_WEAK",
+  /*  3 = */ "STB_NUM",
+  /*  4 = */ "STB_FILE",
+  /*  5 = */ NULL,
+  /*  6 = */ NULL,
+  /*  7 = */ NULL,
+  /*  8 = */ NULL,
+  /*  9 = */ NULL,
+  /* 10 = */ "STB_GNU_UNIQUE",
+  /* 11 = */ NULL,
+  /* 12 = */ "STB_HIOS",
+  /* 13 = */ "STB_LOPROC",
+  /* 14 = */ NULL,
+  /* 15 = */ "STB_HIPROC",
+};
+
+static const char *const stv_visibility_names[] = {
+  /* 0 =  */ "STV_DEFAULT",
+  /* 1 =  */ "STV_INTERNAL",
+  /* 2 =  */ "STV_HIDDEN",
+  /* 3 =  */ "STV_PROTECTED",
+};
+
+/* clang-format on */
+
+/** Get ST_TYPE name according to its value.  */
+#define GET_ST_TYPE_NAME(s) st_type_names[ELF64_ST_TYPE(s)]
+
+/** Get ST_BIND name according to its value.  */
+#define GET_ST_BIND_NAME(s) st_bind_names[ELF64_ST_BIND(s)]
+
+/** Get STV_VISIBILITY name according to its value.  */
+#define GET_STV_VISIBILITY_NAME(s) stv_visibility_names[ELF64_ST_VISIBILITY(s)]
+
+#define FREE_AND_NULLIFY(x) \
+  do { \
+    free((void *) (x)); \
+    (x) = NULL; \
+  } while (0);
+
+/** @brief dump symbol
+ *
+ * Dump a struct symbol to stdout for debugging purposes.
+ *
+ */
+static void
+dump_symbol(const struct symbol *symbol)
+{
+  FILE *o = stdout;
+  while (symbol) {
+    fprintf(o, "  symbols: 0x%lx\n", (unsigned long)symbol);
+    fprintf(o, "    name    : %s\n", symbol->name);
+    fprintf(o, "    offset  : 0x%lx\n", symbol->offset);
+    fprintf(o, "    size    : 0x%d\n", symbol->size);
+    fprintf(o, "    st_info : %u\n", (unsigned)symbol->st_info);
+    fprintf(o, "      type  : %s\n", GET_ST_TYPE_NAME(symbol->st_info));
+    fprintf(o, "      bind  : %s\n", GET_ST_BIND_NAME(symbol->st_info));
+    fprintf(o, "    st_other: %u\n", (unsigned)symbol->st_other);
+    fprintf(o, "      visibi: %s\n", GET_STV_VISIBILITY_NAME(symbol->st_other));
+
+    symbol = symbol->next;
+  }
+}
+
+/** @brief dump ulp_so_info
+ *
+ * Dump a struct ulp_so_info to stdout for debugging purposes.
+ *
+ */
+void
+dump_ulp_so_info(const struct ulp_so_info *info)
+{
+  fprintf(stdout, "ulp_so_info: 0x%lx\n", (uintptr_t) info);
+  fprintf(stdout, "  name: %s\n", info->name);
+  fprintf(stdout, "  buildid: %s\n", buildid_to_string(info->buildid));
+  dump_symbol(info->symbols);
+}
+
+/** Shorthand to create a new JSON string.  */
+#define JSTR(x) json_object_new_string(x)
+
+/** Shorthand to create a new JSON int.  */
+#define JINT(x) json_object_new_int(x)
+
+/** @brief Get a JSON object representing a symbol.
+ *
+ * Output the symbol structure as a JSON node.
+ *
+ * @param symbol    symbol object.
+ *
+ * @return json object representing symbol.
+ */
+static json_object *
+get_json_symbol(const struct symbol *symbol)
+{
+  json_object *js = json_object_new_object();
+
+  assert(js && "Could not create json object.");
+
+  json_object_object_add(js, "name", JSTR(symbol->name));
+  json_object_object_add(js, "offset", JINT(symbol->offset));
+  json_object_object_add(js, "size", JINT(symbol->size));
+  json_object_object_add(js, "st_info", JINT(symbol->st_info));
+  json_object_object_add(js, "st_other", JINT(symbol->st_other));
+
+  return js;
+}
+
+/** @brief Output ulp_so_info structure in JSON form.
+ *
+ * Dumps the `ulp_so_info` in JSON format to the `stream`.
+ *
+ * @param stream    The file stream to be output.
+ * @param info      The ulp_so_info object.
+ */
+void
+write_ulp_so_info_json(FILE *stream, const struct ulp_so_info *info)
+{
+  /* Create root JSON object.  */
+  json_object *root = json_object_new_object();
+
+  /* Assert that we got the root.  */
+  assert(root && "Error allocating root JSON object.");
+
+  /* Create a library object that will hold the content of one library.  */
+  json_object *library = json_object_new_object();
+
+  /* Add the interesting stuff there.  */
+  json_object_object_add(library, "name", JSTR(info->name));
+  json_object_object_add(library, "buildid", JSTR(buildid_to_string(info->buildid)));
+
+  /* Add the list of symbols.  */
+  json_object *symbols = json_object_new_array();
+  struct symbol *symbol;
+  for (symbol = info->symbols; symbol != NULL; symbol = symbol->next) {
+    json_object *jsymbol = get_json_symbol(symbol);
+
+    /* Add a single symbol to the array of symbols.  */
+    json_object_array_add(symbols, jsymbol);
+  }
+
+  /* Add array of symbols to the library.  */
+  json_object_object_add(library, "symbols", symbols);
+
+  /* Add library to the root of JSON tree.  */
+  json_object_object_add(root, "library", library);
+
+  fputs(json_object_to_json_string_ext(root, JSON_C_TO_STRING_PRETTY), stream);
+
+  /* Release stuff.  */
+  json_object_put(root);
+}
+
+/** @brief Get a list of symbols on given section.
+ *
+ * Given an elf object and a symbol table section (dynsym or symtab), compute
+ * the list of symbols in this section.
+ *
+ * @param elf       The elf object.
+ * @param s         The section to list the symbols.
+ *
+ * @return          The list of symbols. NULL if something goes wrong.
+ */
+static struct symbol *
+get_list_of_symbols_in_section(Elf *elf, Elf_Scn *s)
+{
+  struct symbol *symbol_head = NULL;
+
+  int nsyms, i;
+  char *sym_name;
+  Elf_Data *data;
+  GElf_Shdr sh;
+  GElf_Sym sym;
+
+  gelf_getshdr(s, &sh);
+
+  nsyms = sh.sh_size / sh.sh_entsize;
+  data = elf_getdata(s, NULL);
+  if (!data) {
+    WARN("Unable to get section data.");
+    return NULL;
+  }
+
+  for (i = 0; i < nsyms; i++) {
+    gelf_getsym(data, i, &sym);
+    sym_name = elf_strptr(elf, sh.sh_link, sym.st_name);
+
+    /* Do not include symbols that seems invalid.  */
+    if (sym.st_value == 0 || *sym_name == '\0') {
+      continue;
+    }
+
+    struct symbol *symbol = calloc(1, sizeof(struct symbol));
+    symbol->name = strdup(sym_name);
+    symbol->offset = sym.st_value;
+    symbol->size = sym.st_size;
+    symbol->st_info = sym.st_info;
+    symbol->st_other = sym.st_other;
+
+    symbol->next = symbol_head;
+    symbol_head = symbol;
+
+  }
+  return symbol_head;
+}
+
+/** @brief Build list of symbols in the elf object.
+ *
+ * The ELF object have a list of exported symbols and may have a list of
+ * private symbols in their .dynsym and .symtab sections, respectivelly.
+ * This function will list all symbols from both sections and return a list
+ * with all of them.
+ *
+ * @param elf    The elf object
+ *
+ * @return       A list containing all symbols in the elf object.
+ */
+struct symbol *
+build_symbols_list(Elf *elf)
+{
+  /* Get the externalized symbols.  */
+  Elf_Scn *dynsym = get_dynsym(elf);
+
+  /* Get the private symbols.  */
+  Elf_Scn *symtab = get_symtab(elf);
+
+  /* Iterate on the dynsym first and list all symbols there.  */
+  struct symbol *symbols_dynsym = get_list_of_symbols_in_section(elf, dynsym);
+  struct symbol *symbols_symtab = get_list_of_symbols_in_section(elf, symtab);
+
+
+  /* Merge both lists.  */
+  struct symbol **it = &symbols_dynsym;
+  for (; *it != NULL; it = &(*it)->next)
+    ;
+  *it = symbols_symtab;
+
+  return symbols_dynsym;
+}
+
+/** @brief Open target .so file and collect all useful information for
+ *  livepatching purposes.
+ *
+ *  This function will open the .so file and parse the ELF file and collect
+ *  the information we need in order to create a livepatch, such as the
+ *  library name, build id, and list of symbols.
+ */
+struct ulp_so_info *
+parse_so_elf(const char *target_path)
+{
+  /* Ensure that we are never called with NULL argument.  */
+  assert(target_path != NULL && "Provide a proper string.");
+
+  /* Load ELF.  */
+  int fd;
+  Elf *elf = load_elf(target_path, &fd);
+
+  /* Create the ulp_so_info object.  */
+  struct ulp_so_info *so_info = calloc(1, sizeof(struct ulp_so_info));
+  assert(so_info && "Error calling calloc.");
+
+  /* Get library name.  */
+  so_info->name = strdup(get_basename(target_path));
+
+  /* Load the build id of elf object.  */
+  unsigned buildid_len = 0;
+  if (get_elf_buildid(elf, (char *) so_info->buildid, &buildid_len)) {
+    WARN("Elf in %s do not have a build id.", target_path);
+    unload_elf(&elf, &fd);
+    return NULL;
+  }
+
+  assert(buildid_len == BUILDID_LEN &&
+    "Build ID len doesn't match BUILDID_LEN macro");
+
+  /* Build list of symbols.  */
+  so_info->symbols = build_symbols_list(elf);
+
+  unload_elf(&elf, &fd);
+  return so_info;
+}
+
+
+/** @brief Parse json_object containing symbols array.
+ *
+ * When parsing the JSON input file, this function grabs the object
+ * containing the symbols array and return the list of struct symbols
+ * that can be used by packer.
+ *
+ * @param symbol_array             Object containing the array of symbols.
+ *
+ * @return struct symbol list of symbols, or NULL if an error occured.
+ */
+static struct symbol *
+parse_symbols_json(json_object *symbol_array)
+{
+  array_list *array = json_object_get_array(symbol_array);
+  size_t len = json_object_array_length(symbol_array);
+
+  if (array == NULL || len == 0) {
+    /* No symbols or invalid JSON.  */
+    return NULL;
+  }
+
+  struct symbol *first = NULL;
+  struct symbol *current = first;
+
+  for (size_t i = 0; i < len; i++) {
+    json_object *obj = array->array[i];
+
+    json_object *jname = json_object_object_get(obj, "name");
+    json_object *joffset = json_object_object_get(obj, "offset");
+    json_object *jsize = json_object_object_get(obj, "size");
+    json_object *jst_info = json_object_object_get(obj, "st_info");
+    json_object *jst_other = json_object_object_get(obj, "st_other");
+
+    const char *name = strdup(json_object_get_string(jname));
+    Elf64_Addr offset = json_object_get_int(joffset);
+    size_t size = json_object_get_int(jsize);
+    unsigned char st_info = (unsigned char) json_object_get_int(jst_info);
+    unsigned char st_other = (unsigned char) json_object_get_int(jst_other);
+
+    struct symbol *new = calloc(1, sizeof(struct symbol));
+    assert(new && "Error allocating a new symbol element.");
+
+    new->name = name;
+    new->offset = offset;
+    new->size = size;
+    new->st_info = st_info;
+    new->st_other = st_other;
+
+    /* Append to the symbols linked list.  */
+    if (current == NULL) {
+      current = new;
+      first = new;
+    } else {
+      current->next = new;
+      current = new;
+    }
+  }
+
+  return first;
+}
+
+/** @brief Compare two ulp_so_info to find if they are equal
+ *
+ * Do a deep analysis to find this.
+ *
+ * @return 0 if equal, anything else if not.
+ */
+bool
+so_info_equal(struct ulp_so_info *a, struct ulp_so_info *b)
+{
+  if (strcmp(a->name, b->name) != 0) {
+    return false;
+  }
+
+  if (memcmp(a->buildid, b->buildid, BUILDID_LEN) != 0) {
+    return false;
+  }
+
+  struct symbol *a_cur = a->symbols;
+  struct symbol *b_cur = b->symbols;
+
+  while (a_cur && b_cur) {
+    if (strcmp(a_cur->name, b_cur->name) != 0 ||
+        a_cur->offset != b_cur->offset ||
+        a_cur->size != b_cur->size ||
+        a_cur->st_info != b_cur->st_info ||
+        a_cur->st_other != b_cur->st_other
+    ) {
+      return false;
+    }
+
+    a_cur = a_cur->next;
+    b_cur = b_cur->next;
+  }
+
+  /* If we are here and they are equal, then both of them is NULL.  */
+  if (a_cur == NULL && b_cur == NULL) {
+    return true;
+  }
+
+  /* This means there are more stuff in one of the lists and therefore is not
+     equal.  */
+
+  return false;
+}
+
+/** @brief Load the relevant so data which was stored in JSON format.
+ *
+ * After the .so file was parsed and its relevant content dumped in a JSON
+ * format, this function reads the JSON to reload the ulp_so_info structure so
+ * that it can be used by packer later.
+ *
+ * @param path          Path to the JSON file.
+ *
+ * @return              The ulp_so_info structure from the JSON, or NULL in case
+ *                      of error.
+ */
+struct ulp_so_info *
+parse_so_json(const char *path)
+{
+  int ret;
+
+  json_object *root = json_object_from_file(path);
+  assert(root && "Unable to build root object.");
+
+  json_object *library = json_object_object_get(root, "library");
+  if (!library) {
+    WARN("%s is not valid: no library node.", path);
+    return NULL;
+  }
+
+  json_object *name = json_object_object_get(library, "name");
+  if (!name) {
+    WARN("%s is not valid: no name.", path);
+    return NULL;
+  }
+
+  json_object *buildid = json_object_object_get(library, "buildid");
+  if (!buildid) {
+    WARN("%s is not valid: no buildid.", path);
+    return NULL;
+  }
+
+  struct ulp_so_info *so_info = calloc(1, sizeof(struct ulp_so_info));
+  assert(so_info && "Error calling calloc.");
+
+  so_info->name = strdup(json_object_get_string(name));
+
+  ret = str_to_buildid(so_info->buildid, json_object_get_string(buildid));
+  if (ret) {
+    WARN("%s is not valid: invalid buildid.", path);
+    release_so_info(so_info);
+    return NULL;
+  }
+
+  /* Parse the symbols array.  */
+  json_object *jsymbols = json_object_object_get(library, "symbols");
+  struct symbol *symbols = parse_symbols_json(jsymbols);
+  so_info->symbols = symbols;
+
+  /* Release stuff.  */
+  json_object_put(root);
+
+  return so_info;
+}
+
+/** @brief Release the `symbol` linked list object.
+ *
+ * Release all dynamic memory structures allocated when the symbol linked list
+ * was created.
+ *
+ * @param symbol    Symbol to release.
+ */
+void
+release_symbol(struct symbol *symbol)
+{
+  struct symbol *next;
+
+  while (symbol) {
+    FREE_AND_NULLIFY(symbol->name);
+    next = symbol->next;
+    FREE_AND_NULLIFY(symbol);
+    symbol = next;
+  }
+}
+
+/** @brief Release an `ulp_so_info` object.
+ *
+ * Release all dynamic memory structures allocated when the ulp_so_info object
+ * was created.
+ *
+ * @param info    ulp_so_info to release.
+ */
+void
+release_so_info(struct ulp_so_info *info)
+{
+  if (info) {
+    FREE_AND_NULLIFY(info->name);
+    release_symbol(info->symbols);
+    FREE_AND_NULLIFY(info);
+  }
+}
+
+int
+run_extract(struct arguments *arguments)
+{
+  /* Path to input livepatch library target.  */
+  const char *input_file = arguments->args[0];
+
+  /* arguments->metadata is what is captured by the -o option.  */
+  const char *output_file = arguments->metadata;
+
+  /* In case the output is NULL then default to out.json.  */
+  if (output_file == NULL)
+    output_file = "out.json";
+
+  struct ulp_so_info *info = parse_so_elf(input_file);
+  FILE *out;
+
+  if (!strcmp(output_file, "-"))
+    out = fopen("test.json", "w");
+  else
+    out = stdout;
+
+  /* Write the ulp_so_info structure as a JSON object.  */
+  write_ulp_so_info_json(out, info);
+
+  if (!strcmp(output_file, "-"))
+    fclose(out);
+
+  release_so_info(info);
+  return 0;
+}

--- a/tools/extract.h
+++ b/tools/extract.h
@@ -2,6 +2,12 @@
 #define _EXTRACT_H_
 
 #include "arguments.h"
+#include "ulp_common.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <link.h>
+#include <libelf.h>
 
 /** Struct containing useful information for Userspace Livepatching retrieved
  *  from the target .so file.
@@ -56,6 +62,12 @@ bool so_info_equal(struct ulp_so_info *a, struct ulp_so_info *b);
 
 struct ulp_so_info *parse_so_json(const char *path);
 
+void dump_ulp_so_info(const struct ulp_so_info *info);
+
+struct symbol *get_symbol_with_name(struct ulp_so_info *info, const char *sym);
+
 int run_extract(struct arguments *arguments);
+
+struct ulp_so_info *ulp_so_info_open(const char *path);
 
 #endif /* _EXTRACT_H_.  */

--- a/tools/extract.h
+++ b/tools/extract.h
@@ -1,0 +1,61 @@
+#ifndef _EXTRACT_H_
+#define _EXTRACT_H_
+
+#include "arguments.h"
+
+/** Struct containing useful information for Userspace Livepatching retrieved
+ *  from the target .so file.
+ */
+struct symbol
+{
+  /** Name of the symbol (function, variable).  */
+  const char *name;
+
+  /** Offset of such symbol.  */
+  ElfW(Addr) offset;
+
+  /** Size of symbol.  */
+  Elf32_Word size;
+
+  /** Symbol visibility.  See elf.h.  */
+  unsigned char st_info;
+
+  /** Symbol type and binding.  See elf.h.  */
+  unsigned char st_other;
+
+  /** Next symbol in the symbol table chain.  */
+  struct symbol *next;
+};
+
+/** Struct containing the useful information for userspace livepatching
+ *  retrieved from the .so file.
+ */
+struct ulp_so_info
+{
+  /** Name of the library.  Empty for none.  */
+  const char *name;
+
+  /** Build ID for library.  Zero for unitialized.  */
+  unsigned char buildid[BUILDID_LEN];
+
+  /** List of symbols extracted from the target library.  */
+  struct symbol *symbols;
+};
+
+void release_so_info(struct ulp_so_info *);
+
+void release_symbol(struct symbol *symbol);
+
+void write_ulp_so_info_json(FILE *stream, const struct ulp_so_info *info);
+
+struct symbol *build_symbols_list(Elf *elf);
+
+struct ulp_so_info *parse_so_elf(const char *target_path);
+
+bool so_info_equal(struct ulp_so_info *a, struct ulp_so_info *b);
+
+struct ulp_so_info *parse_so_json(const char *path);
+
+int run_extract(struct arguments *arguments);
+
+#endif /* _EXTRACT_H_.  */

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1651,6 +1651,14 @@ revert_patches_from_lib(struct ulp_process *process, const char *lib_name)
 
   DEBUG("beginning patches removal.");
 
+  /* In case the revert_library is set to target, then we must revert the
+   * target library of the patch.  */
+  if (!strcmp(lib_name, "target") && ulp.objs) {
+    /* TODO: We only support one target library per patch.  If we want to
+       expand this, this also has to be changed.  */
+    lib_name = ulp.objs->name;
+  }
+
   if (!process->all_threads_hijacked) {
     WARN("not all threads hijacked.");
     return EUNKNOWN;

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -36,6 +36,8 @@ Elf *load_elf(const char *obj, int *fd);
 
 Elf_Scn *get_dynsym(Elf *elf);
 
+Elf_Scn *get_symtab(Elf *elf);
+
 Elf_Scn *get_build_id_note(Elf *elf);
 
 int get_ulp_elf_metadata(const char *filename, struct ulp_metadata *ulp);
@@ -50,6 +52,8 @@ int add_dependency(struct ulp_metadata *ulp, struct ulp_dependency *dep,
                    const char *filename);
 
 int get_build_id(Elf_Scn *s, char *buildid_buf, unsigned *len);
+
+int get_elf_buildid(Elf *elf, char *buf, unsigned *len);
 
 void *get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search);
 

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -49,7 +49,7 @@ int create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename);
 int add_dependency(struct ulp_metadata *ulp, struct ulp_dependency *dep,
                    const char *filename);
 
-int get_build_id(Elf_Scn *s, struct ulp_object *obj);
+int get_build_id(Elf_Scn *s, char *buildid_buf, unsigned *len);
 
 void *get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search);
 

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -29,6 +29,7 @@
 #include "ulp_common.h"
 
 struct arguments;
+struct ulp_so_info;
 
 void unload_elf(Elf **elf, int *fd);
 
@@ -40,11 +41,9 @@ Elf_Scn *get_symtab(Elf *elf);
 
 Elf_Scn *get_build_id_note(Elf *elf);
 
-int get_ulp_elf_metadata(const char *filename, struct ulp_metadata *ulp);
-
 int get_object_metadata(Elf *elf, struct ulp_object *obj);
 
-int get_elf_tgt_addrs(Elf *, struct ulp_object *, Elf_Scn *st1, Elf_Scn *st2);
+int get_target_addrs(struct ulp_so_info *, struct ulp_object *);
 
 int create_patch_metadata_file(struct ulp_metadata *ulp, const char *filename);
 

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -139,6 +139,13 @@ trigger_one_process(struct ulp_process *target, int retries,
         FATAL("fatal error reverting livepatches (hijacked execution).");
         retry = 0;
       }
+      /* In case we received a `No Target Lib` error, ignore it because we are
+         doing atomic patching and it may be the first patch we are trying to
+         apply.  */
+      if (livepatch && result == ENOTARGETLIB) {
+        result = 0;
+      }
+
       if (result) {
         DEBUG("live patching revert %d failed (attempt #%d).", target->pid,
               (retries - retry));
@@ -193,7 +200,7 @@ metadata_clean:
   }
   else {
     char buf[128];
-    snprintf(buf, 128, "reverted all patches from %s", revert_library);
+    snprintf(buf, 128, "reverted all patches from '%s'", revert_library);
     entry->patch_name = strdup(buf);
   }
   entry->err = ret;

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -140,7 +140,9 @@ static struct argp_option options[] = {
   { "buildid", 'b', 0, 0, "Print the build id", 0 },
   { 0, 0, 0, 0, "trigger command only:", 0 },
   { "retries", 'r', "N", 0, "Retry N times if process busy", 0 },
-  { "revert-all", ULP_OP_REVERT_ALL, "LIB", 0, "Revert all patches from LIB",
+  { "revert-all", ULP_OP_REVERT_ALL, "LIB", 0,
+    "Revert all patches from LIB. If LIB=target, then all patches from the "
+    "target library within the passed livepatch will be reverted.",
     0 },
   { "timeout", ULP_OP_TIMEOUT, "t", 0,
     "Set trigger timeout to t seconds (default 200s)", 0 },

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -38,6 +38,7 @@
 #include "patches.h"
 #include "post.h"
 #include "trigger.h"
+#include "extract.h"
 
 #include <unistd.h>
 
@@ -188,6 +189,7 @@ command_from_string(const char *str)
     { "dump", ULP_DUMP },         { "packer", ULP_PACKER },
     { "trigger", ULP_TRIGGER },   { "post", ULP_POST },
     { "messages", ULP_MESSAGES }, { "livepatchable", ULP_LIVEPATCHABLE },
+    { "extract", ULP_EXTRACT },
   };
 
   size_t i;
@@ -223,6 +225,7 @@ handle_end_of_arguments(const struct argp_state *state)
         argp_error(state, "Too many arguments.");
       break;
 
+    case ULP_EXTRACT:
     case ULP_PACKER:
     case ULP_CHECK:
       if (state->arg_num < 2)
@@ -479,6 +482,10 @@ main(int argc, char **argv, char *envp[] __attribute__((unused)))
 
     case ULP_LIVEPATCHABLE:
       ret = run_livepatchable(&arguments);
+      break;
+
+    case ULP_EXTRACT:
+      ret = run_extract(&arguments);
       break;
   }
 

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -31,6 +31,7 @@
 #include "check.h"
 #include "config.h"
 #include "dump.h"
+#include "extract.h"
 #include "introspection.h"
 #include "livepatchable.h"
 #include "messages.h"
@@ -38,7 +39,6 @@
 #include "patches.h"
 #include "post.h"
 #include "trigger.h"
-#include "extract.h"
 
 #include <unistd.h>
 


### PR DESCRIPTION
    Add support for target library dumps
    
    In order to avoid requiring the original library to build the
    livepatches, we now support the use of dumps of the target library as
    input. This should remove the need to package the original libraries
    into tarballs when building the livepatches.
    
    The process can now be done by:
    
    1- Running:
    ```
    $ ulp extract targetlib.so -o targetlib.so.json
    ```
    
    2- Specify the .json file as a livepatch target in the dsc file:
    
    ```
     liblivepatchcontainer_livepatch1.so
     @path/to/liblivepatch.so.json
     ...
    ```
    
    The old way of specifying the library itself also works and is
    provided as compatibility.
    
    Signed-off-by: Giuliano Belinassi <gbelinas