### PR TITLE
Fix linkage of libunwind and file descriptor leak

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -24,5 +24,3 @@ noinst_LTLIBRARIES = libcommon.la
 AM_CFLAGS += -I$(abs_top_srcdir)/include
 
 libcommon_la_SOURCES = common.c
-libcommon_la_LIBADD = $(LIBUNWIND_LIBS)
-

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -2307,6 +2307,7 @@ library_range_detect(pid_t pid, char *library, uintptr_t *range_start,
     WARN("error parsing /proc/%d/maps: %s", pid, strerror(errno));
 
   free(line);
+  fclose(fp);
 
   if (errno)
     return errno;


### PR DESCRIPTION
Previously, libpulp.so.0 were being linked against libunwind, but no function of this library is called inside libpulp. This library also do not have any constructors. Hence, only the tools need to link against this library.

Also fix a file descriptor leak in the stack check code. Since it is not used in the package updater, this is not critical.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>