### PR TITLE
Refactor and document functions/structues

### DIFF
--- a/include/ulp.h
+++ b/include/ulp.h
@@ -28,20 +28,50 @@
 #include "ulp_common.h"
 
 /* ULP Structures */
+
+/** The ulp_detour_root object represents a single function that is patched.
+ *
+ * This object is created when a function is patched, and is unique per
+ * function. If another patch modifies that function, this object is modified
+ * rather than create a new one.  A new object is only created if a new function
+ * is patched.
+ */
 struct ulp_detour_root
 {
+  /** Index of the detour root. Increases as new roots are created.  */
   unsigned int index;
+
+  /** Address of patched function.  */
   void *patched_addr;
+
+  /** Next root in the root chain.  */
   struct ulp_detour_root *next;
+
+  /** Detour objects associated with this root.  */
   struct ulp_detour *detours;
 };
 
+/** The ulp_detour object represents a new function comming from a patch.
+ *
+ * This object is created when a new function is set as a replacement to a old
+ * function that was livepatched.  If another patch modifies that function, a
+ * new object is created and the old one is set as inactive.
+ */
 struct ulp_detour
 {
+  /** ID of origin patch.  */
   unsigned char patch_id[32];
+
+  /** ID of the detour object.  Increases as patches are applied. */
   unsigned long universe;
+
+  /** Address to the new function.  */
   void *target_addr;
+
+  /** Is patch active?  */
   char active;
+
+  /** Next in chain.  */
   struct ulp_detour *next;
 };
 
@@ -99,7 +129,7 @@ struct ulp_applied_patch *ulp_get_applied_patch(const unsigned char *id);
 
 int ulp_revert_patch(unsigned char *id);
 
-int ulp_state_remove(struct ulp_applied_patch *rm_patch);
+int ulp_state_remove(unsigned char *id);
 
 int ulp_revert_all_units(unsigned char *patch_id);
 

--- a/include/ulp.h
+++ b/include/ulp.h
@@ -33,8 +33,8 @@
  *
  * This object is created when a function is patched, and is unique per
  * function. If another patch modifies that function, this object is modified
- * rather than create a new one.  A new object is only created if a new function
- * is patched.
+ * rather than create a new one.  A new object is only created if a new
+ * function is patched.
  */
 struct ulp_detour_root
 {

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -43,6 +43,16 @@
 /** Intel endbr64 instruction optcode.  */
 #define INSN_ENDBR64 0xf3, 0x0f, 0x1e, 0xfa
 
+/** Free whatever pointer given and set it to NULL.  */
+#define FREE_AND_NULLIFY(x) \
+  do { \
+    if (x) { \
+      free((void *)(x)); \
+      (x) = NULL; \
+    } \
+  } \
+  while (0);
+
 extern __thread int __ulp_pending;
 
 /** Used on __tls_get_addr(tls_index *).  */

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -675,6 +675,13 @@ dl_locks_held(void)
   return (dl_load_lock->__data.__lock || dl_load_write_lock->__data.__lock);
 }
 
+/** @brief Lock the `flag` lock to indicate that this process in being patched.
+ *
+ * This function will lock the `flag` lock, which indicates that this process
+ * is being analyzed by libpulp tools.  This runs when the thread was hijacked.
+ *
+ * @return   0 if lock was not held, 1 if held.
+ */
 int
 __ulp_asunsafe_trylock(void)
 {
@@ -688,12 +695,15 @@ __ulp_asunsafe_trylock(void)
   return 0;
 }
 
+/** @brief Unlock the `flag` lock.  */
 int
 __ulp_asunsafe_unlock(void)
 {
   __sync_fetch_and_and(&flag, 0);
   return 0;
 }
+
+/* Interposed functions.  */
 
 void
 free(void *ptr)

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -336,195 +336,6 @@ dl_find_base_addr(struct dl_phdr_info *info, size_t size, void *data)
   return 1;
 }
 
-/* Enable a cache on libpulp's side to speedup the symbol discovery process. */
-#ifdef ENABLE_DLINFO_CACHE
-
-struct ulp_dlinfo_cache *__ulp_dlinfo_cache = NULL;
-static pthread_mutex_t dlinfo_cache_lock = PTHREAD_MUTEX_INITIALIZER;
-
-static struct ulp_dlinfo_cache *
-new_dlinfo_cache(ElfW(Addr) bias, ElfW(Addr) dynsym, ElfW(Addr) dynstr,
-                 int num_symbols, const char *buildid_addr, int buildid_len)
-{
-  struct ulp_dlinfo_cache *ret =
-      (struct ulp_dlinfo_cache *)calloc(1, sizeof(*ret));
-  if (ret == NULL) {
-    return NULL;
-  }
-
-  if (buildid_len > 32) {
-    buildid_len = 32;
-  }
-
-  ret->bias = bias;
-  ret->dynsym = dynsym;
-  ret->dynstr = dynstr;
-  ret->num_symbols = num_symbols;
-  memcpy(ret->buildid, buildid_addr, buildid_len);
-
-  ret->sentinel = 0xdeadf00d;
-
-  return ret;
-}
-
-static void
-release_dlinfo_cache(struct ulp_dlinfo_cache *cache)
-{
-  struct ulp_dlinfo_cache *next;
-
-  while (cache != NULL) {
-    next = cache->next;
-    free(cache);
-    cache = next;
-  }
-}
-
-static int
-dl_build_cache(struct dl_phdr_info *info, size_t size,
-               void *a __attribute__((unused)))
-{
-  /* We call the symbol table as dynsym because that is most likely to be the
-   * section in DT_SYMTAB.  However, this is not necessary true in all cases.
-   */
-  Elf64_Sym *dynsym = NULL;
-  const char *dynstr = NULL;
-  int *hash_addr;
-
-  int i;
-  int num_symbols = 0;
-
-  const char *buildid_addr = NULL;
-  unsigned buildid_len = 0;
-  unsigned name_len = 0;
-
-  /* Sanity check if size matches the size of the struct.  */
-  if (size != sizeof(*info)) {
-    libpulp_errx(EXIT_FAILURE, "dl_phdr_info size is unexpected");
-    return 0;
-  }
-
-  /* Pointers to linux-vdso.so are invalid, so skip this library.  */
-  if (!strcmp(info->dlpi_name, "linux-vdso.so.1"))
-    return 0;
-
-  /* Iterate each program headers to find the information we need. */
-  for (i = 0; i < info->dlpi_phnum; i++) {
-    const Elf64_Phdr *phdr_addr = &info->dlpi_phdr[i];
-
-    /* We are interested in symbols, so look for the dynamic symbols in the
-     * PT_DYNAMIC tag. */
-    if (phdr_addr->p_type == PT_DYNAMIC) {
-
-      /* The address in p_paddr is relative to the .so header, so we need to
-       * add the base address where the .so was mapped in the process. In case
-       * it is the binary itself, dlpi_addr is zero.  */
-      Elf64_Dyn *dyn = (Elf64_Dyn *)(info->dlpi_addr + phdr_addr->p_paddr);
-
-      /* Iterate over each tag in this section.  */
-      for (; dyn->d_tag != DT_NULL; dyn++) {
-        switch (dyn->d_tag) {
-          case DT_SYMTAB:
-            dynsym = (Elf64_Sym *)dyn->d_un.d_ptr;
-            break;
-
-          case DT_STRTAB:
-            dynstr = (const char *)dyn->d_un.d_ptr;
-            break;
-
-          case DT_SYMENT:
-            /* This section stores the size of a symbol entry. So compare it
-             * with the size of Elf64_Sym as a sanity check.  */
-            if (dyn->d_un.d_val != sizeof(Elf64_Sym)) {
-              libpulp_errx(EXIT_FAILURE, "DT_SYMENT value of %s is unexpected",
-                           info->dlpi_name);
-              return 0;
-            }
-            break;
-
-          case DT_HASH:
-            /* Look at the hash section for the number of the symbols in the
-             * symbol table.  This section structure in memory is:
-             *
-             * hash_t nbuckets;
-             * hash_t nchains;
-             * hash_t buckets[nbuckets];
-             * hash_t chain[nchains];
-             *
-             * hash_t is either int32_t or int64_t according to the arch.
-             * On x86_64 it is 32-bits.
-             * */
-            hash_addr = (int *)dyn->d_un.d_ptr;
-            num_symbols = hash_addr[1]; /* Get nchains.  */
-            break;
-        }
-      }
-    }
-    else if (phdr_addr->p_type == PT_NOTE) {
-      /* We are after the build id.  */
-
-      ElfW(Addr) note_addr = info->dlpi_addr + phdr_addr->p_paddr;
-      unsigned sec_size = phdr_addr->p_memsz;
-      ElfW(Addr) note_addr_end = note_addr + sec_size;
-
-      do {
-        /* Get the note section.  */
-        ElfW(Nhdr) *note = (void *)note_addr;
-
-        name_len = note->n_namesz;
-        buildid_len = note->n_descsz;
-
-        /* Align with the 4 bytes boundary.  */
-        buildid_len += buildid_len % 4;
-        name_len += name_len % 4;
-
-        if (note->n_type == NT_GNU_BUILD_ID) {
-          /* Build id note section found.  */
-          buildid_addr = (const char *)(note_addr + sizeof(*note) + name_len);
-          break;
-        }
-
-        note_addr += buildid_len + name_len + 12;
-      }
-      while (note_addr < note_addr_end);
-    }
-  }
-
-  /* With the symbol table identified, find the wanted symbol.  */
-  if (dynstr && dynsym && num_symbols > 0) {
-    struct ulp_dlinfo_cache *cache = new_dlinfo_cache(
-        (ElfW(Addr))info->dlpi_addr, (ElfW(Addr))dynsym, (ElfW(Addr))dynstr,
-        num_symbols, buildid_addr, buildid_len);
-
-    if (cache == NULL) {
-      libpulp_errx(EXIT_FAILURE,
-                   "malloc returned NULL when building dlinfo cache");
-    }
-
-    cache->next = __ulp_dlinfo_cache;
-    __ulp_dlinfo_cache = cache;
-  }
-  return 0;
-}
-
-static void
-release_dlcache(void)
-{
-  release_dlinfo_cache(__ulp_dlinfo_cache);
-  __ulp_dlinfo_cache = NULL;
-}
-
-static void
-build_dlcache(void)
-{
-  pthread_mutex_lock(&dlinfo_cache_lock);
-  {
-    release_dlcache();
-    dl_iterate_phdr(dl_build_cache, NULL);
-  }
-  pthread_mutex_unlock(&dlinfo_cache_lock);
-}
-#endif /* ENABLE_DLINFO_CACHE.  */
-
 void *
 get_loaded_library_base_addr(const char *library)
 {
@@ -657,10 +468,6 @@ __ulp_asunsafe_begin(void)
   libpulp_crash_assert(real_posix_memalign);
 
   get_ld_global_locks();
-
-#ifdef ENABLE_DLINFO_CACHE
-  build_dlcache();
-#endif
 }
 
 static bool
@@ -867,11 +674,6 @@ dlopen(const char *filename, int flags)
 
   __sync_fetch_and_add(&flag, 1);
   result = real_dlopen(filename, flags);
-#if 0
-  if (result) {
-    build_dlcache();
-  }
-#endif
   __sync_fetch_and_sub(&flag, 1);
 
   return result;
@@ -887,11 +689,6 @@ dlmopen(Lmid_t nsid, const char *file, int mode)
 
   __sync_fetch_and_add(&flag, 1);
   result = real_dlmopen(nsid, file, mode);
-#if 0
-  if (result) {
-    build_dlcache();
-  }
-#endif
   __sync_fetch_and_sub(&flag, 1);
 
   return result;
@@ -907,11 +704,6 @@ dlclose(void *handle)
 
   __sync_fetch_and_add(&flag, 1);
   result = real_dlclose(handle);
-#ifdef ENABLE_DLINFO_CACHE
-  if (result == 0) {
-    build_dlcache();
-  }
-#endif
   __sync_fetch_and_sub(&flag, 1);
 
   return result;

--- a/tools/extract.c
+++ b/tools/extract.c
@@ -124,13 +124,6 @@ static const char *const stv_visibility_names[] = {
 /** Get STV_VISIBILITY name according to its value.  */
 #define GET_STV_VISIBILITY_NAME(s) stv_visibility_names[ELF64_ST_VISIBILITY(s)]
 
-#define FREE_AND_NULLIFY(x) \
-  do { \
-    free((void *)(x)); \
-    (x) = NULL; \
-  } \
-  while (0);
-
 /** @brief dump symbol
  *
  * Dump a struct symbol to stdout for debugging purposes.


### PR DESCRIPTION
This commit add comments to function and structures in an attempt to
explain what they do more clearly.  This also flags stuff that has been
deprecated and neeeds further revision.

This also removes the old dlinfo cache which was never used, thus this code is not needed anymore.
