### PR TITLE
Fix `patches` not detecting libcrypto as livepatchable

### DIFF
--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Look for the number of symbols and how many symbols will need to be read to
+# decide if a library is livepatchable or not in /usr/lib64 to collect
+# statistics.
+
+get_first_function_symbol()
+{
+  local realfile=$(readlink -f $1)
+  local symbol=$(readelf -D -sW $realfile | grep -E "FUNC[ ]*GLOBAL[ ]*DEFAULT[ ]*[0-9]+" | head -n 1 | awk '{ print substr($1, 1, length($1)-1) }')
+  local num_symbols=$(readelf -D -sW $realfile | tail -n 1 | awk '{ print substr($1, 1, length($1)-1) }')
+
+  echo "Analyzing $realfile"
+  echo "$realfile, $symbol", $num_symbols >> output.csv
+}
+
+rm -f output.csv
+for so in $(find "/usr/lib64/" -name "*.so"); do
+  get_first_function_symbol $so
+done
+
+sort -u output.csv -o output.csv

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -437,8 +437,11 @@ is_library_livepatchable(struct ulp_applied_patch *patch,
     ehdr_addr = 0x400000UL;
   }
 
-  /* Only look the first 64 symbols, else we may take too much time.  */
-  int len = MIN(obj->num_symbols, 64);
+  /* FIXME: Some applications take a very long time to decide if library is
+     livepatchable because the library has a lot of symbols.  In this case we
+     limit the number of symbols to read to a constant value.  Statistics shows
+     that 8000 is a reasonable number (see issue #159).  */
+  int len = MIN(obj->num_symbols, 8000);
 
   for (i = 0; i < len; i++) {
     ElfW(Sym) sym;


### PR DESCRIPTION
libcrypto.so.1.1 required to read around 200 symbols in order for `patch` to detect it as a livepatchable library.  Hence we bump the number of symbols to read from 64 to 8000.  This value of 8000 is found by analyzing all libraries found in /usr/lib64 and its subfolders for how many symbols it would need to be read in order to decide if the library is livepatchable.

Workarround #159