### PR TITLE
Fix case where trigger is called with pid of non-livepatchable process

### DIFF
--- a/include/error_common.h
+++ b/include/error_common.h
@@ -73,7 +73,7 @@ typedef int ulp_error_t;
     "No link map in object", \
     "Invalid program header", \
     "Unable to find process entry address", \
-    "Libpulp not found", \
+    "Libpulp not found in target process", \
     "Thread attach failure", \
     "Thread dettach failure", \
     "Invalid .ulp file", \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -589,7 +589,8 @@ TESTS = \
   stress.py \
   tempfiles.py \
   pcqueue.py \
-  comments.py
+  comments.py \
+  nolibpulp.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/nolibpulp.py
+++ b/tests/nolibpulp.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import time
+
+import testsuite
+from testsuite import ulptool
+
+errorcode = 1
+child = testsuite.spawn('parameters', env=None)
+
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+try:
+    child.livepatch('.libs/libparameters_livepatch1.so')
+except subprocess.CalledProcessError:
+    errorcode = 0
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8', reject='8-7-6-5-4-3-2-1');
+
+child.close(force=True)
+exit(errorcode)

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1201,26 +1201,6 @@ parse_libs_dynobj(struct ulp_process *process)
     obj_link_map = aux_link_map->l_next;
   }
 
-  if (parse_lib_dynobj(process->dynobj_libpulp, process)) {
-    DEBUG("libpulp not loaded, thus live patching not possible.");
-    return ENOLIBPULP;
-  }
-
-#ifdef ENABLE_DLINFO_CACHE
-  if (get_dynobj_elf_by_cache(process)) {
-    DEBUG("libpulp dlinfo cache not available");
-  }
-#endif
-
-  /* Iterate over the link map to build the list of libraries. */
-  struct ulp_dynobj *obj;
-  for (obj = process->dynobj_targets; obj != NULL; obj = obj->next) {
-    if (obj != process->dynobj_libpulp) {
-      if (parse_lib_dynobj(obj, process))
-        break;
-    }
-  }
-
   /* When libpulp has been loaded (usually with LD_PRELOAD),
    * parse_lib_dynobj will find the symbols it provides, such as
    * __ulp_trigger, which are all required for userspace live-patching.
@@ -1230,6 +1210,20 @@ parse_libs_dynobj(struct ulp_process *process)
   if (process->dynobj_libpulp == NULL) {
     DEBUG("libpulp not loaded, thus live patching not possible.");
     return ENOLIBPULP;
+  }
+
+  if (parse_lib_dynobj(process->dynobj_libpulp, process)) {
+    DEBUG("libpulp not loaded, thus live patching not possible.");
+    return ENOLIBPULP;
+  }
+
+  /* Iterate over the link map to build the list of libraries. */
+  struct ulp_dynobj *obj;
+  for (obj = process->dynobj_targets; obj != NULL; obj = obj->next) {
+    if (obj != process->dynobj_libpulp) {
+      if (parse_lib_dynobj(obj, process))
+        break;
+    }
   }
 
   return 0;


### PR DESCRIPTION
If trigger was called with -p PID, where PID is a process without libpulp loaded, then trigger crashed.  This commit fixes this problem by moving the necessary check accordingly.