### PR TITLE
Add mechanism to opt-out livepatching

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -562,3 +562,17 @@ is_directory(const char *path)
   else
     return S_ISDIR(s.st_mode);
 }
+
+uid_t
+get_process_owner(pid_t pid)
+{
+  char procpath[128];
+  snprintf(procpath, sizeof(procpath), "/proc/%d/loginuid", pid);
+
+  struct stat info;
+  if (stat(procpath, &info)) {
+    return 0;
+  }
+
+  return info.st_uid;
+}

--- a/include/error.h
+++ b/include/error.h
@@ -37,6 +37,8 @@ void exit(int);
  **/
 ulp_error_t get_libpulp_error_state(void);
 
+void set_libpulp_error_state(ulp_error_t);
+
 /** @brief Check if libpulp is in an fatal error state.
  *
  * If a fatal error has occured, libpulp cannot continue livepatching processes

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -60,6 +60,8 @@ typedef int ulp_error_t;
 #define EHOOKNOTRUN   277 /** libpulp.so hook routine not run.  */
 #define ENOPATCHABLE  278 /** Function is not livepatchable.  */
 #define EWILDNOMATCH  279 /** No file matched wildcard.  */
+#define EUSRBLOCKED   280 /** Livepatch blocked by user request.  */
+#define EOLDLIBPULP   281 /** Libpulp version too old.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -90,6 +92,8 @@ typedef int ulp_error_t;
     "libpulp.so hook routine not run", \
     "Function is not livepatchable", \
     "No file matched wildcard", \
+    "Livepatching blocked by user request", \
+    "Libpulp version is too old", \
   }
 /* clang-format on */
 

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -62,6 +62,7 @@ typedef int ulp_error_t;
 #define EWILDNOMATCH  279 /** No file matched wildcard.  */
 #define EUSRBLOCKED   280 /** Livepatch blocked by user request.  */
 #define EOLDLIBPULP   281 /** Libpulp version too old.  */
+#define EINITFAIL     282 /** Libpulp initialization failure.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -94,6 +95,7 @@ typedef int ulp_error_t;
     "No file matched wildcard", \
     "Livepatching blocked by user request", \
     "Libpulp version is too old", \
+    "Libpulp initialization failure", \
   }
 /* clang-format on */
 

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -24,6 +24,7 @@
 
 #include <elf.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define OUT_PATCH_NAME "metadata.ulp"

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -246,6 +246,8 @@ void free_metadata(struct ulp_metadata *);
 
 bool is_directory(const char *path);
 
+uid_t get_process_owner(pid_t pid);
+
 #define FATAL(format, ...) \
   do { \
     fprintf(stderr, "ulp: " format "\n", ##__VA_ARGS__); \

--- a/lib/error.c
+++ b/lib/error.c
@@ -36,19 +36,25 @@ __libpulp_unique_exit_point()
 #include <stdarg.h>
 #include <stdio.h>
 
-/** Holds the current error state.  */
-static ulp_error_t libpulp_error_state = ENONE;
+/** Holds the current error state.  Externally visible to ulp tool.  */
+ulp_error_t __ulp_error_state = ENONE;
 
 ulp_error_t
 get_libpulp_error_state()
 {
-  return libpulp_error_state;
+  return __ulp_error_state;
 }
 
 bool
 libpulp_is_in_error_state()
 {
   return !(get_libpulp_error_state() == ENONE);
+}
+
+void
+set_libpulp_error_state(ulp_error_t state)
+{
+  __ulp_error_state = state;
 }
 
 void
@@ -60,7 +66,7 @@ libpulp_assert_func(const char *file, const char *func, int line,
 
   msgq_push("In file = %s, function = %s, line = %d: assertion failure: %lu\n",
             file, func, line, expression);
-  libpulp_error_state = EUNKNOWN;
+  set_libpulp_error_state(EUNKNOWN);
 }
 
 void
@@ -74,7 +80,7 @@ libpulp_errx_func(const char *file, const char *func, int line, int eval,
   msgq_push(fmt, args);
   va_end(args);
 
-  libpulp_error_state = EUNKNOWN;
+  set_libpulp_error_state(EUNKNOWN);
 }
 
 void
@@ -83,7 +89,7 @@ libpulp_exit_func(const char *file, const char *func, int line, int val)
   msgq_push("In file = %s, function = %s, line = %d: exit: %d\n", file, func,
             line, val);
 
-  libpulp_error_state = EUNKNOWN;
+  set_libpulp_error_state(EUNKNOWN);
 }
 
 void

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -507,6 +507,7 @@ maybe_disable_livepatching_on_user(void)
   for (wildcard = strtok(names, ":"); wildcard != NULL;
        wildcard = strtok(NULL, ":")) {
     if (isnumber(wildcard) && strtoul(wildcard, NULL, 10) == uid) {
+      set_libpulp_error_state(EUSRBLOCKED);
       WARN("Matched uid %s: livepatching disabled by user request.", wildcard);
       break;
     }
@@ -559,6 +560,7 @@ maybe_disable_livepatching_on_group(void)
   for (wildcard = strtok(names, ":"); wildcard != NULL;
        wildcard = strtok(NULL, ":")) {
     if (isnumber(wildcard) && strtoul(wildcard, NULL, 10) == gid) {
+      set_libpulp_error_state(EUSRBLOCKED);
       WARN("Matched gid %s: livepatching disabled by user request.", wildcard);
       break;
     }

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -24,7 +24,8 @@
     __ulp_get_global_universe;
     __ulp_msg_queue;
     __ulp_metadata_buffer;
-    __ulp_dlinfo_cache;
+    __ulp_error_state;
+    __ulp_enable_or_disable_patching;
   local:
     *;
 };

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -1399,6 +1399,45 @@ ulp_revert_all_units(unsigned char *patch_id)
   return 1;
 }
 
+/** @brief Enable or disable livepatching in this process.
+ *
+ * This function enables or disables livepatching according to libpulp's error
+ * state. If libpulp is not in a error state, it sets it to EUSRBLOCKED, which
+ * flags that the user requested this process to not be livepatched anymore.
+ * In case current state is EUSRBLOCKED, it sets to ENONE, thus re-enabling
+ * livepatching.
+ *
+ * If libpulp is in an error state outside of EUSRBLOCKED or ENONE, then
+ * changing this state is blocked as it is in a real error state, thus
+ * patching is blocked.
+ *
+ * @return error state after change.
+ **/
+int
+ulp_enable_or_disable_patching(void)
+{
+  ulp_error_t state = get_libpulp_error_state();
+
+  switch (state) {
+    case ENONE:
+      /* Block livepatching.  */
+      set_libpulp_error_state(EUSRBLOCKED);
+      break;
+
+    case EUSRBLOCKED:
+      /* Unblock livepatching.  */
+      set_libpulp_error_state(ENONE);
+      break;
+
+    default:
+      /* Libpulp is in an error state and we can not continue.  */
+      break;
+  }
+
+  /* Return the current state.  */
+  return get_libpulp_error_state();
+}
+
 /* these are here for debugging reasons :) */
 void
 dump_ulp_patching_state(void)

--- a/lib/ulp_interface.S
+++ b/lib/ulp_interface.S
@@ -64,3 +64,10 @@ __ulp_get_global_universe:
     nop
     call   __ulp_get_global_universe_value@PLT
     int3
+
+.global __ulp_enable_or_disable_patching
+__ulp_enable_or_disable_patching:
+    nop
+    nop
+    call ulp_enable_or_disable_patching@PLT
+    int3

--- a/man/ulp.1
+++ b/man/ulp.1
@@ -514,5 +514,30 @@ informations into a JSON file specified by
 .PP
 .TP
 .SH EXIT STATUS
-.TP
+.TPut
 exits 0 on success, anything else on error.
+
+.\"-------------------------------------------
+
+.SH SET_PATCHABLE
+.TP
+.SH NAME
+ulp set_patchable \- Enable/disable livepatching on target process
+.TP
+.SH SYNOPSIS
+.TP
+.B ulp set_livepatchable -p process
+.I enable/disable
+.TP
+.SH DESCRIPTION
+.TP
+Enable or disable the livepatching capability of process specified by
+-p
+.I WILDCARD.
+If WILDCARD is a number, then it is assumed to be the PID of the process.
+The program will output which processes were modified.
+.PP
+.TP
+.SH EXIT STATUS
+.TP
+Always returns 0.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -590,7 +590,8 @@ TESTS = \
   tempfiles.py \
   pcqueue.py \
   comments.py \
-  nolibpulp.py
+  nolibpulp.py \
+  set_patchable.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -592,7 +592,9 @@ TESTS = \
   comments.py \
   nolibpulp.py \
   set_patchable.py \
-  path_disable.py
+  path_disable.py \
+  user_disable.py \
+  group_disable.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -591,7 +591,8 @@ TESTS = \
   pcqueue.py \
   comments.py \
   nolibpulp.py \
-  set_patchable.py
+  set_patchable.py \
+  path_disable.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/group_disable.py
+++ b/tests/group_disable.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 
 #   libpulp - User-space Livepatching Library
@@ -21,48 +20,13 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import os
 import testsuite
+import os
 
-# Live patch selection variable
-child = testsuite.spawn('numserv')
+env = { 'LD_PRELOAD': '../lib/.libs/libpulp.so',
+        'LIBPULP_DISABLE_ON_GROUPS': str(os.getgid()) }
 
-child.expect('Waiting for input.')
-
-child.sendline('dozen')
-child.expect('12');
-
-child.sendline('hundred')
-child.expect('100');
-
-child.livepatch('.libs/libdozens_livepatch1.so')
-
-child.sendline('dozen')
-child.expect('13', reject='12');
-
-child.sendline('hundred')
-child.expect('100');
-
-child.disable_livepatching()
-child.livepatch('.libs/libhundreds_livepatch1.so', sanity=False)
-
-child.sendline('dozen')
-child.expect('13', reject='12');
-
-child.sendline('hundred')
-child.expect('100', reject='200');
-
-child.enable_livepatching()
-child.livepatch('.libs/libhundreds_livepatch1.so')
-
-child.sendline('hundred')
-child.expect('200', reject='100');
-
-child.close(force=True)
-
-#-- Test user name and group id mode.
-
-child = testsuite.spawn('numserv')
+child = testsuite.spawn('numserv', env=env)
 
 child.expect('Waiting for input.')
 
@@ -72,8 +36,7 @@ child.expect('12');
 child.sendline('hundred')
 child.expect('100');
 
-testsuite.childless_disable_livepatching('numserv', os.getgid())
-child.livepatch('.libs/libhundreds_livepatch1.so', sanity=False)
+child.livepatch('.libs/libdozens_livepatch1.so', sanity=False)
 
 child.sendline('dozen')
 child.expect('12', reject='13');

--- a/tests/path_disable.py
+++ b/tests/path_disable.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2023 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+import testsuite
+
+env = { 'LD_PRELOAD': '../lib/.libs/libpulp.so',
+        'LIBPULP_DISABLE_ON_PATH': '*/numserv' }
+
+child = testsuite.spawn('numserv', env=env)
+
+child.expect('Waiting for input.')
+
+child.sendline('dozen')
+child.expect('12');
+
+child.sendline('hundred')
+child.expect('100');
+
+child.livepatch('.libs/libdozens_livepatch1.so', sanity=False)
+
+child.sendline('dozen')
+child.expect('12', reject='13');
+
+child.close(force=True)
+exit(0)

--- a/tests/set_patchable.py
+++ b/tests/set_patchable.py
@@ -1,0 +1,62 @@
+
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2023 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+import testsuite
+
+# Live patch selection variable
+child = testsuite.spawn('numserv')
+
+child.expect('Waiting for input.')
+
+child.sendline('dozen')
+child.expect('12');
+
+child.sendline('hundred')
+child.expect('100');
+
+child.livepatch('.libs/libdozens_livepatch1.so')
+
+child.sendline('dozen')
+child.expect('13', reject='12');
+
+child.sendline('hundred')
+child.expect('100');
+
+child.disable_livepatching()
+child.livepatch('.libs/libhundreds_livepatch1.so', sanity=False)
+
+child.sendline('dozen')
+child.expect('13', reject='12');
+
+child.sendline('hundred')
+child.expect('100', reject='200');
+
+child.enable_livepatching()
+child.livepatch('.libs/libhundreds_livepatch1.so')
+
+child.sendline('hundred')
+child.expect('200', reject='100');
+
+child.close(force=True)
+exit(0)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -368,6 +368,28 @@ class spawn(pexpect.spawn):
     msgs = tool.stdout.decode()
     return str(msgs)
 
+  def enable_livepatching(self):
+    self.sanity(pid=self.pid)
+    command = [ulptool, 'set_patchable', '-p', str(self.pid), 'enable']
+
+    try:
+      tool = subprocess.run(command, timeout=10, stdout=subprocess.PIPE)
+    except:
+      rai2e
+
+    return tool.returncode
+
+  def disable_livepatching(self):
+    self.sanity(pid=self.pid)
+    command = [ulptool, 'set_patchable', '-p', str(self.pid), 'disable']
+
+    try:
+      tool = subprocess.run(command, timeout=10, stdout=subprocess.PIPE)
+    except:
+      raise
+
+    return tool.returncode
+
 
 def childless_livepatch(wildcard, timeout=10, retries=1,
             verbose=False, quiet=False, revert_lib=None):

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -423,3 +423,28 @@ def childless_livepatch(wildcard, timeout=10, retries=1,
     tool.check_returncode()
 
     print('Live patch applied/reverted successfully.')
+
+def childless_disable_livepatching(process_wildcard, userid, timeout=10):
+
+    # Build command-line from arguments
+    command = [ulptool, "set_patchable"]
+    if process_wildcard is not None:
+      command.append("-p")
+      command.append(process_wildcard)
+    if userid is not None:
+      command.append("-u")
+      command.append(str(userid))
+
+    command.append('disable')
+
+    # Apply the live patch and check for common errors
+    try:
+      print('Disabling livepatches.')
+      tool = subprocess.run(command, timeout=timeout)
+    except subprocess.TimeoutExpired:
+      print('Command run timed out')
+      raise
+
+    # The trigger tool returns 0 on success, so use check_returncode(),
+    # which asserts that, and raises CalledProcessError otherwise.
+    tool.check_returncode()

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -34,7 +34,8 @@ noinst_HEADERS = \
   livepatchable.h \
   elf-extra.h \
   pcqueue.h \
-  extract.h
+  extract.h \
+  set_patchable.h
 
 ulp_SOURCES = \
   ulp.c \
@@ -51,7 +52,9 @@ ulp_SOURCES = \
   livepatchable.c \
   elf-extra.c \
   pcqueue.c \
-  extract.c
+  extract.c \
+  set_patchable.c
+
 ulp_LDADD = $(top_builddir)/common/libcommon.la -lelf -ljson-c -lpthread -ldl $(LIBUNWIND_LIBS)
 
 # Ensure access to the include directory

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -48,6 +48,7 @@ struct arguments
   const char *library;
   const char *metadata;
   const char *process_wildcard;
+  const char *user_wildcard;
   const char *prefix;
   command_t command;
   int retries;

--- a/tools/extract.h
+++ b/tools/extract.h
@@ -4,10 +4,10 @@
 #include "arguments.h"
 #include "ulp_common.h"
 
+#include <libelf.h>
+#include <link.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <link.h>
-#include <libelf.h>
 
 /** Struct containing useful information for Userspace Livepatching retrieved
  *  from the target .so file.

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -25,6 +25,7 @@
 #include <link.h>
 #include <stdbool.h>
 
+#include "error_common.h"
 #include "ptrace.h"
 #include "ulp_common.h"
 
@@ -111,7 +112,8 @@ struct ulp_dynobj
   Elf64_Addr msg_queue;
   Elf64_Addr revert_all;
   Elf64_Addr metadata_buffer;
-  Elf64_Addr dlinfo_cache;
+  Elf64_Addr error_state;
+  Elf64_Addr enable_disable_patching;
   /* end FIXME.  */
 
   struct thread_state *thread_states;
@@ -194,5 +196,7 @@ get_process_name(struct ulp_process *process)
 {
   return get_basename(process->dynobj_main->filename);
 }
+
+ulp_error_t get_libpulp_error_state(struct ulp_process *);
 
 #endif

--- a/tools/patches.h
+++ b/tools/patches.h
@@ -36,6 +36,9 @@ struct ulp_process_iterator
   struct ulp_process *last;
 
   const char *wildcard;
+  const char *user_wildcard;
+  uid_t target_uid;
+
   DIR *slashproc;
   struct dirent *subdir;
 
@@ -44,13 +47,16 @@ struct ulp_process_iterator
 
 struct ulp_process *process_list_next(struct ulp_process_iterator *);
 struct ulp_process *process_list_begin(struct ulp_process_iterator *,
-                                       const char *);
+                                       const char *, const char *);
 int process_list_end(struct ulp_process_iterator *);
 
-#define FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, wildcard) \
+#define FOR_EACH_ULP_PROCESS_FROM_USER_WILDCARD(p, wildcard, user_wildcard) \
   struct ulp_process_iterator _it; \
-  for (p = process_list_begin(&_it, wildcard); process_list_end(&_it); \
-       p = process_list_next(&_it))
+  for (p = process_list_begin(&_it, wildcard, user_wildcard); \
+       process_list_end(&_it); p = process_list_next(&_it))
+
+#define FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, wildcard) \
+  FOR_EACH_ULP_PROCESS_FROM_USER_WILDCARD(p, wildcard, NULL)
 
 #define FOR_EACH_ULP_PROCESS(p) FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, NULL)
 

--- a/tools/set_patchable.c
+++ b/tools/set_patchable.c
@@ -1,0 +1,140 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2023 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "set_patchable.h"
+#include "arguments.h"
+#include "introspection.h"
+#include "patches.h"
+#include "ulp_common.h"
+
+#include <stddef.h>
+#include <unistd.h>
+
+/** Enable or disable threading in process discovery.  */
+extern bool enable_threading;
+
+/** Run the __ulp_enable_disable_livepatching in libpulp.  */
+static int
+run_enable_disable_patching(struct ulp_process *p)
+{
+  struct ulp_thread *thread = p->main_thread;
+  struct user_regs_struct context = thread->context;
+  Elf64_Addr routine = p->dynobj_libpulp->enable_disable_patching;
+
+  int ret = run_and_redirect(thread->tid, &context, routine);
+
+  if (ret) {
+    return ret;
+  }
+
+  return context.rax;
+}
+
+/** @brief Enable or disable livepatching on remote process.
+ *
+ * Given a remote process `p`, this function will enable or disable the
+ * livepatch capabilites of `p` according to `enable` variable.
+ *
+ * @param p        Process to enable/disable livepatching.
+ * @param enable   Enable or disable livepatching.
+ * @param retries  How many attempts if the process is busy?
+ *
+ * @return         ENONE if success, anything else if error.
+ **/
+static ulp_error_t
+enable_or_disable_patching(struct ulp_process *p, bool enable, int retries)
+{
+  ulp_error_t state = get_libpulp_error_state(p);
+  int ret;
+
+  if ((state == ENONE && enable == false) ||
+      (state == EUSRBLOCKED && enable == true)) {
+
+    for (int i = 0; i < retries; i++) {
+      if (hijack_threads(p)) {
+        WARN("unable to hijack process with pid: %d.", p->pid);
+        break;
+      }
+
+      ret = run_enable_disable_patching(p);
+
+      if (restore_threads(p)) {
+        WARN("unable to restore thread in process with pid: %d.", p->pid);
+        break;
+      }
+
+      if (ret != EAGAIN) {
+        break;
+      }
+
+      DEBUG("enabling/disabling libpulp failed: locks were busy.");
+      usleep(1000);
+    }
+
+    /* ulp_enable_or_disable_patchig returns the new error state, so check if
+       the returned state is what we expect to.  */
+    if ((ret == ENONE && enable) || (ret == EUSRBLOCKED && !enable)) {
+      WARN("Process %s (pid: %d): livepatching is now %s.",
+           get_target_binary_name(p->pid), p->pid,
+           enable ? "enabled" : "disabled");
+    }
+    else {
+      WARN("Unable to change status of process %d: %s (libpulp in error "
+           "state).",
+           p->pid, libpulp_strerror(ret));
+    }
+
+    return ENONE;
+  }
+
+  /* Can not do that, as libpulp is in error state.  */
+  return state;
+}
+
+int
+run_set_patchable(struct arguments *arguments)
+{
+  ulp_quiet = arguments->quiet;
+  ulp_verbose = arguments->verbose;
+  enable_threading = !arguments->disable_threads;
+  const char *process_wildcard = arguments->process_wildcard;
+  int retries = arguments->retries;
+  bool enable;
+  struct ulp_process *p;
+
+  if (!strcasecmp(arguments->args[0], "enable")) {
+    enable = true;
+  }
+  else if (!strcmp(arguments->args[0], "disable")) {
+    enable = false;
+  }
+  else {
+    WARN("Empty argument. Expected: 'enable' or 'disable'");
+    return 1;
+  }
+
+  FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, process_wildcard)
+  {
+    enable_or_disable_patching(p, enable, retries);
+  }
+
+  return 0;
+}

--- a/tools/set_patchable.h
+++ b/tools/set_patchable.h
@@ -1,7 +1,7 @@
 /*
  *  libpulp - User-space Livepatching Library
  *
- *  Copyright (C) 2017-2021 SUSE Software Solutions GmbH
+ *  Copyright (C) 2020-2023 SUSE Software Solutions GmbH
  *
  *  This file is part of libpulp.
  *
@@ -19,47 +19,11 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef SET_PATCHABLE_H
+#define SET_PATCHABLE_H
 
-#include "config.h"
+struct arguments;
 
-#define ARGS_MAX 1
-
-typedef enum
-{
-  ULP_NONE,
-  ULP_PATCHES,
-  ULP_CHECK,
-  ULP_DUMP,
-  ULP_PACKER,
-  ULP_TRIGGER,
-  ULP_POST,
-  ULP_MESSAGES,
-  ULP_LIVEPATCHABLE,
-  ULP_EXTRACT,
-  ULP_SET_PATCHABLE,
-} command_t;
-
-struct arguments
-{
-  const char *args[ARGS_MAX];
-  const char *livepatch;
-  const char *library;
-  const char *metadata;
-  const char *process_wildcard;
-  const char *prefix;
-  command_t command;
-  int retries;
-  int quiet;
-  int verbose;
-  int buildid;
-  int revert;
-  int disable_threads;
-  int recursive;
-#if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
-  int check_stack;
-#endif
-};
+int run_set_patchable(struct arguments *);
 
 #endif

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -327,6 +327,13 @@ wildcard_clean:
   return ret;
 }
 
+static bool
+skippable_error(ulp_error_t err)
+{
+  return err == EBUILDID || err == ENOTARGETLIB || err == EUSRBLOCKED ||
+         err == EWILDNOMATCH;
+}
+
 static void
 print_patched_unpatched(struct ulp_process *p, bool summarize)
 {
@@ -388,7 +395,7 @@ print_patched_unpatched(struct ulp_process *p, bool summarize)
 
   printf("  %s (pid: %d):", get_process_name(curr_item), pid);
   if (summarized) {
-    if (err == EBUILDID || err == ENOTARGETLIB) {
+    if (skippable_error(err)) {
       change_color(TERM_COLOR_YELLOW);
       printf(" SKIPPED");
       change_color(TERM_COLOR_RESET);
@@ -488,7 +495,7 @@ trigger_many_processes(const char *process_wildcard, int retries,
 
     /* If the livepatch failed because the patch wasn't targeted to the
        proccess, we ignore because we are batch processing.  */
-    if (r == EBUILDID || r == ENOTARGETLIB || r == EWILDNOMATCH) {
+    if (skippable_error(r)) {
       skippes++;
     }
     else {

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -612,6 +612,11 @@ run_trigger(struct arguments *arguments)
   pid_t pid = 0;
   int ret;
 
+  if (arguments->user_wildcard) {
+    WARN("error: user wildcard is currently unsupported in trigger");
+    return ENOSYS;
+  }
+
   /* Set global static prefix variable.  */
   prefix = arguments->prefix;
 

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -136,6 +136,7 @@ static struct argp_option options[] = {
   { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
   { 0, 0, 0, 0, "patches, check & trigger commands only:", 0 },
   { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+  { "user", 'u', "user", 0, "User name, wildcard, or UID", 0 },
   { "disable-threading", ULP_OP_DISABLE_THREADING, 0, 0,
     "Do not launch additional threads", 0 },
   { 0, 0, 0, 0, "dump & patches command only:", 0 },
@@ -286,8 +287,6 @@ handle_end_of_arguments(const struct argp_state *state)
       break;
 
     case ULP_SET_PATCHABLE:
-      if (arguments->process_wildcard == 0)
-        argp_error(state, "process is mandatory in 'set_patchable' command.");
       if (state->arg_num < 2)
         argp_error(state, "passing 'enable' or 'disable' in ARG1 is mandatory "
                           "in set_patches.");
@@ -352,6 +351,10 @@ parser(int key, char *arg, struct argp_state *state)
 
     case ULP_OP_RECURSIVE:
       arguments->recursive = 1;
+      break;
+
+    case 'u':
+      arguments->user_wildcard = arg;
       break;
 
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK


### PR DESCRIPTION
This PR adds the ability for libpulp to disable livepatching given some parameters.

The first parameter is through the environment variables:

1. `LIBPULP_DISABLE_ON_PATH=path_wildcard1:path_wildcard2:...`
2. `LIBPULP_DISABLE_ON_USERS=user_wildcard1:user_wildcard2:...`
3. `LIBPULP_DISABLE_ON_GROUPS=group1_wildcard:group2_wildcard:...`

Each variable accepts multiple arguments separated by `:` token. For example, if the variable:
 `LIBPULP_DISABLE_ON_PATH=*/numserv:/home/*`
is defined, then all processes with name `numserv` and all processes which binary is housed in /home/* will have livepatching blocked regardless if run with libpulp or not.

Another example:
 `LIBPULP_DISABLE_ON_USERS=:1000:giulianob`
will block livepatching on users with uid = 1000 or which name is `giulianob`. 

Now, since the user may want to re-enable livepatching, we provide the new command `set_patchable`:
```
$ ulp set_patchable -p <PID|NAME> -u <UID|USERNAME> enable
``` 
Example:
```
$ ulp set_patchable -p numserv enable
```
will enable livepatching to all processes with name `numserv`.