### PR TITLE
Detect if mprotect is blocked when libpulp is initalized

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,7 +39,7 @@ jobs:
       run: zypper -n install autoconf-archive libelf-devel
         python3-pexpect python3-psutil libunwind-devel
         git gcc gcc-c++ clang libtool make dash valgrind gzip
-        findutils libjson-c-devel
+        findutils libjson-c-devel libseccomp-devel
     - uses: actions/checkout@v2
     - name: bootstrap
       run: ./bootstrap

--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,11 @@ AC_SUBST([LIBUNWIND_LIBS], ["-lunwind-generic -lunwind-ptrace -lunwind"])
 AC_DEFINE(ENABLE_STACK_CHECK, 1, [Enable stack checking routines]),
 AC_DEFINE(ENABLE_STACK_CHECK, 0, [Disable stack checking routines]))
 
+# Check if libseccomp is present.  This is required for testing.
+CFLAGS="$CFLAGS -I/usr/include/libseccomp/"
+AC_CHECK_HEADER([seccomp.h],,
+AC_MSG_ERROR([libseccomp required for testing.]))
+
 # Check if Doxygen is present.
 AC_CHECK_PROGS([DOXYGEN], [doxygen])
 AC_CHECK_PROGS([DOT], [dot])

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -63,6 +63,7 @@ typedef int ulp_error_t;
 #define EUSRBLOCKED   280 /** Livepatch blocked by user request.  */
 #define EOLDLIBPULP   281 /** Libpulp version too old.  */
 #define EINITFAIL     282 /** Libpulp initialization failure.  */
+#define MPROTFAIL     283 /** Page permission error.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -96,6 +97,7 @@ typedef int ulp_error_t;
     "Livepatching blocked by user request", \
     "Libpulp version is too old", \
     "Libpulp initialization failure", \
+    "Page permission error", \
   }
 /* clang-format on */
 

--- a/include/ulp.h
+++ b/include/ulp.h
@@ -75,10 +75,6 @@ struct ulp_detour
   struct ulp_detour *next;
 };
 
-/* libpulp TLS variables */
-
-__thread int __ulp_pending = 0;
-
 /* libpulp livepatching interfaces */
 int __ulp_apply_patch();
 
@@ -149,3 +145,5 @@ struct ulp_detour_root *get_detour_root_by_index(unsigned int idx);
 void dump_ulp_patching_state(void);
 
 void dump_ulp_detours(void);
+
+int memory_protection_get(uintptr_t addr);

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -54,8 +54,6 @@
   } \
   while (0);
 
-extern __thread int __ulp_pending;
-
 /** Used on __tls_get_addr(tls_index *).  */
 typedef struct
 {

--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -40,6 +40,7 @@
 #include "ld_rtld.h"
 #include "msg_queue.h"
 #include "ulp_common.h"
+#include "ulp.h"
 
 /* This header should be included last, as it poisons some symbols.  */
 #include "error.h"
@@ -579,6 +580,37 @@ maybe_disable_livepatching_on_group(void)
   free(names);
 }
 
+/** @brief Check if we can change the page protection flags on .text segment.
+ *
+ * Depending of the security options the application was launched with (example
+ * systemd's MemoryDenyWriteExecute=yes), we can't change any page flags to
+ * executable.  This function will check if we can change the page protection
+ * and set libpulp to an error state if otherwise.
+ */
+static void
+check_page_protection(void)
+{
+  void *function = real_malloc;
+  uintptr_t page, page_mask;
+  int prot;
+  unsigned long page_size = getpagesize();
+
+  page_mask = ~(page_size - 1);
+  page = ((uintptr_t)function) & page_mask;
+  prot = memory_protection_get(page);
+
+  /* Check if the memory protection actually makes sense.  */
+  libpulp_crash_assert(prot & (PROT_READ | PROT_EXEC));
+
+  /* Check if we can set the memory protection of this page.  */
+  if (mprotect((void *)page, page_size, prot)) {
+    /* We can't set the page.  Probably MemoryWriteExecute is set to yes.  */
+    set_libpulp_error_state(MPROTFAIL);
+    WARN("Livepatch disabled: unable to set memory protection, most likely due" \
+         " to security configuration.");
+  }
+}
+
 __attribute__((constructor)) void
 __ulp_asunsafe_begin(void)
 {
@@ -632,6 +664,8 @@ __ulp_asunsafe_begin(void)
   maybe_disable_livepatching_on_path();
   maybe_disable_livepatching_on_user();
   maybe_disable_livepatching_on_group();
+
+  check_page_protection();
 }
 
 static bool

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -1233,11 +1233,11 @@ ulp_patch_addr(void *old_faddr, void *new_faddr, int enable)
   /* Set the writable bit on affected pages. */
   if (mprotect((void *)page1, page_size, prot1 | PROT_WRITE)) {
     WARN("Memory protection set error (1st page)");
-    return errno;
+    return MPROTFAIL;
   }
   if (mprotect((void *)page2, page_size, prot2 | PROT_WRITE)) {
     WARN("Memory protection set error (2nd page)");
-    return errno;
+    return MPROTFAIL;
   }
 
   /* Actually patch the prologue. */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -419,7 +419,8 @@ check_PROGRAMS = \
   dlsym \
   stress \
   pcqueue \
-  comments
+  comments \
+  block_mprotect
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -547,6 +548,12 @@ comments_SOURCES = comments.c
 comments_CFLAGS = -fpatchable-function-entry=16,14 $(AM_CFLAGS)
 comments_LDADD =
 
+# block_mprotect is a auxiliary program to block page flags change through
+# mprotect.
+block_mprotect_SOURCES = block_mprotect.c
+block_mprotect_CFLAGS = $(AM_CFLAGS) -I/usr/include/libseccomp/
+block_mprotect_LDADD = -lseccomp
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -594,11 +601,14 @@ TESTS = \
   set_patchable.py \
   path_disable.py \
   user_disable.py \
-  group_disable.py
+  group_disable.py \
+  mprotect.py \
+  mprotect_patch.py
 
 XFAIL_TESTS = \
   blocked.py \
-  contract.py
+  contract.py \
+  mprotect_patch.py
 
 # Some tests must run serially because they may interfere with other
 # tests. We use *.log because automake rule that runs the tests are
@@ -621,7 +631,7 @@ SERIAL_TESTS = \
 # Remove the test itself from the dependency list.
 MANYPROCESSES_DEPS = $(filter-out $(SERIAL_TESTS),$(TEST_LOGS))
 STRESS_DEPS = $(MANYPROCESSES_DEPS) manyprocesses.log
-TEMPFILES_DEPS = $(STRESS_DEPS) manyprocesses.log stress.log
+TEMPFILES_DEPS = $(STRESS_DEPS) mprotect.log
 
 manyprocesses.log: $(MANYPROCESSES_DEPS)
 

--- a/tests/block_mprotect.c
+++ b/tests/block_mprotect.c
@@ -1,0 +1,110 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2023 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Program to set a seccomp filter blocking mprotect calls with EXEC flag.  */
+
+#define _GNU_SOURCE
+
+#include <unistd.h>
+#include <seccomp.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <sys/un.h>
+
+static int
+block_mprotect(void)
+{
+  scmp_filter_ctx *seccomp;
+  int r;
+
+  seccomp = seccomp_init(SCMP_ACT_ALLOW);
+  if (!seccomp)
+    return -ENOMEM;
+
+  r = seccomp_rule_add(
+                  seccomp,
+                  SCMP_ACT_ERRNO(EPERM),
+                  SCMP_SYS(mmap),
+                  1,
+                  SCMP_A2(SCMP_CMP_MASKED_EQ, PROT_EXEC|PROT_WRITE, PROT_EXEC|PROT_WRITE));
+  if (r < 0)
+    goto finish;
+
+  r = seccomp_rule_add(
+                  seccomp,
+                  SCMP_ACT_ERRNO(EPERM),
+                  SCMP_SYS(mprotect),
+                  1,
+                  SCMP_A2(SCMP_CMP_MASKED_EQ, PROT_EXEC, PROT_EXEC));
+  if (r < 0)
+    goto finish;
+
+  r = seccomp_attr_set(seccomp, SCMP_FLTATR_CTL_NNP, 0);
+  if (r < 0)
+    goto finish;
+
+  r = seccomp_load(seccomp);
+
+finish:
+  seccomp_release(seccomp);
+  return r;
+}
+
+static int
+launch_process(int argc, char *argv[])
+{
+  (void)argc;
+
+  /* Launch target process.  */
+  return execv(argv[0], (char *const *)argv);
+}
+
+static int
+check_args(int argc, char *argv[])
+{
+  (void)argv;
+
+  if (argc < 2) {
+    /* No target process.  */
+    printf("No target binary specified\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  if (check_args(argc, argv)) {
+    return 1;
+  }
+
+  int r = block_mprotect();
+  if (r) {
+    printf("mprotect protect failure: %s\n", strerror(-r));
+    return 1;
+  }
+
+  return launch_process(--argc, ++argv);
+}

--- a/tests/blocked.py
+++ b/tests/blocked.py
@@ -39,7 +39,7 @@ child.expect('hello')
 # After the live patching, thread1, which is looping outside the
 # library, should produce a different output, whereas thread2, which
 # never leaves the library, should display the old behavior.
-child.livepatch('libblocked_livepatch1.ulp')
+child.livepatch('.libs/libblocked_livepatch1.so')
 
 child.kill(signal.SIGUSR1)
 child.expect('olleh', reject='hello')

--- a/tests/mprotect_patch.py
+++ b/tests/mprotect_patch.py
@@ -20,31 +20,27 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 import testsuite
+import sys
+import os
 
-child = testsuite.spawn('contract')
+if os.geteuid() == 0:
+    child = testsuite.spawn('block_mprotect ./parameters')
+else:
+    print("Test not running as root.", file=sys.stdout)
+    exit(77) # Skip test
 
 child.expect('Waiting for input.')
 
-errors = 0
 child.sendline('')
-child.sendline('')
-child.expect('TYPE A data 128');
-child.sendline('')
-child.expect('TYPE B data 256.000000');
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-# Send the test program into the library.
-child.sendline('')
+child.livepatch('.libs/libparameters_livepatch1.so')
 
-# Apply live patch while inside library
-child.livepatch('.libs/libcontract_livepatch1.so')
-
-# Let the process resume and check fna behavior
 child.sendline('')
-child.expect('TYPE A data 128', reject='Invalid type.')
-
-# Let the process resume and check fnb behavior
-child.sendline('')
-child.expect('TYPE B data 1024.000000', reject='Invalid type.')
+child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
+             reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.close(force=True)
-exit(errors)
+exit(0)


### PR DESCRIPTION
Processes launched by systemd can specify:

MemoryDenyWriteExecute=yes

to block redefining page flags with EXEC flag. This is a problem for livepatching, once we need to redefine the page flags in order to install the redirection jump.

This commit adds a mechanism to detect this case and disable livepatch accordingly, as we don't have the necessary engine features yet to circunvent this problem from `ulp` side.