### PR TITLE
Fix livepatch status counting

### DIFF
--- a/man/ulp.1
+++ b/man/ulp.1
@@ -387,6 +387,10 @@ Before applying the live patch to the target process, revert all livepatches
 applied to the library LIB. If LIB=target, then all patches to the target
 library of the livepatch will be removed.
 .TP
+.B --disable-summarization
+Disable output summarization. This avoids suppression of output 'irrelevant output'
+with regard to skipped livepatches.
+.TP
 .B -q, --quiet
 Do not produce any output.
 .TP

--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -23,8 +23,6 @@ childs = [testsuite.spawn('manyprocesses'),
           testsuite.spawn('manyprocesses'),
           testsuite.spawn('manyprocesses')]
 
-
-
 for child in childs:
     child.expect('Waiting for input.')
 
@@ -32,7 +30,16 @@ for child in childs:
     child.expect('1-2-3-4-5-6-7-8');
     child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-testsuite.childless_livepatch(wildcard='.libs/libmanyprocesses_livepatch1.so', verbose=True, revert_lib='libmanyprocesses.so.0')
+# Try to livepatch everything into the manyprocesses.
+output = testsuite.childless_livepatch(wildcard='.libs/*_livepatch1.so',
+                                       verbose=True,
+                                       revert_lib='libmanyprocesses.so.0',
+                                       capture_output=True)
+
+# Check if the patched counter is correct.
+if output.find("Processes patched: 3, Skipped: 0, Failed: 0") == -1:
+    exit(1)
+
 
 for child in childs:
     child.sendline('')

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -392,7 +392,7 @@ class spawn(pexpect.spawn):
 
 
 def childless_livepatch(wildcard, timeout=10, retries=1,
-            verbose=False, quiet=False, revert_lib=None):
+            verbose=False, quiet=False, revert_lib=None, capture_output=False):
 
     # Build command-line from arguments
     command = [ulptool, "trigger"]
@@ -413,7 +413,10 @@ def childless_livepatch(wildcard, timeout=10, retries=1,
     # Apply the live patch and check for common errors
     try:
       print('Applying/reverting live patch.')
-      tool = subprocess.run(command, timeout=timeout)
+      if capture_output == True:
+        tool = subprocess.run(command, timeout=timeout, stdout=subprocess.PIPE)
+      else:
+        tool = subprocess.run(command, timeout=timeout)
     except subprocess.TimeoutExpired:
       print('Live patching timed out.')
       raise
@@ -423,6 +426,10 @@ def childless_livepatch(wildcard, timeout=10, retries=1,
     tool.check_returncode()
 
     print('Live patch applied/reverted successfully.')
+    if tool.stdout is not None:
+      return tool.stdout.decode()
+    else:
+      return None
 
 def childless_disable_livepatching(process_wildcard, userid, timeout=10):
 

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -58,6 +58,7 @@ struct arguments
   int revert;
   int disable_threads;
   int recursive;
+  int no_summarization;
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   int check_stack;
 #endif

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -129,6 +129,7 @@ static const char doc[] =
 #define ULP_OP_TIMEOUT 259
 #define ULP_OP_DISABLE_THREADING 260
 #define ULP_OP_RECURSIVE 261
+#define ULP_OP_DISABLE_SUMMARIZATION 262
 
 static struct argp_option options[] = {
   { 0, 0, 0, 0, "Options:", 0 },
@@ -148,6 +149,8 @@ static struct argp_option options[] = {
     0 },
   { "timeout", ULP_OP_TIMEOUT, "t", 0,
     "Set trigger timeout to t seconds (default 200s)", 0 },
+  { "disable-summarization", ULP_OP_DISABLE_SUMMARIZATION, 0, 0,
+    "Disable trigger ouput summarization", 0 },
   { "recursive", ULP_OP_RECURSIVE, 0, 0, "Search for patches recursively", 0 },
   { "root", 'R', "PREFIX", 0,
     "Append prefix to livepatch path when passing it to target process", 0 },
@@ -351,6 +354,10 @@ parser(int key, char *arg, struct argp_state *state)
 
     case ULP_OP_RECURSIVE:
       arguments->recursive = 1;
+      break;
+
+    case ULP_OP_DISABLE_SUMMARIZATION:
+      arguments->no_summarization = 1;
       break;
 
     case 'u':


### PR DESCRIPTION
Previously, the output of `ulp trigger` counted the number of prcoesses that were patched skipped and failed, but this counting did break at times because it only remembered the last output of trigger_one_process. Now it logs into a bitfield to log if there was a success skip or failure.

Fixes #177