### PR TITLE
Fix warnings when reverting all patches from a library

### DIFF
--- a/include/error_common.h
+++ b/include/error_common.h
@@ -64,6 +64,7 @@ typedef int ulp_error_t;
 #define EOLDLIBPULP   281 /** Libpulp version too old.  */
 #define EINITFAIL     282 /** Libpulp initialization failure.  */
 #define MPROTFAIL     283 /** Page permission error.  */
+#define ENOPATCH      284 /** No patches installed.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -98,6 +99,7 @@ typedef int ulp_error_t;
     "Libpulp version is too old", \
     "Libpulp initialization failure", \
     "Page permission error", \
+    "No patches installed", \
   }
 /* clang-format on */
 

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -126,6 +126,13 @@ revert_all_patches_from_lib(const char *lib_name)
     patch = next;
   }
 
+  /* In case there is no patch, then check if the target library is indeed
+     loaded.  */
+  if (ret == ENOTARGETLIB &&
+      get_loaded_library_base_addr(lib_basename) != (void *)0xFF) {
+    return ENOPATCH;
+  }
+
   return ret;
 }
 

--- a/tests/revert_all.py
+++ b/tests/revert_all.py
@@ -25,6 +25,14 @@ child = testsuite.spawn('numserv')
 
 child.expect('Waiting for input.')
 
+# Reverting all patches from a library that currently have no patches installed
+# should fail for a single process.
+try:
+  child.livepatch(revert_lib="libhundreds.so.0")
+  exit(1)
+except:
+  pass
+
 child.sendline('hundred')
 child.expect('100')
 

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1673,11 +1673,11 @@ revert_patches_from_lib(struct ulp_process *process, const char *lib_name)
 
   if (context.rax != 0) {
     if (context.rax == EAGAIN)
-      WARN("patches reverse-all failed in libpulp.so: libc/libdl locks were "
-           "busy");
+      DEBUG("patches reverse-all failed in libpulp.so: libc/libdl locks were "
+            "busy");
     else
-      WARN("patches reverse-all failed in libpulp.so: %s",
-           libpulp_strerror(context.rax));
+      DEBUG("patches reverse-all failed in libpulp.so: %s",
+          libpulp_strerror(context.rax));
   }
 
   return context.rax;

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -51,7 +51,7 @@ static bool
 skippable_error(ulp_error_t err)
 {
   return err == EBUILDID || err == ENOTARGETLIB || err == EUSRBLOCKED ||
-         err == EWILDNOMATCH || err == EAPPLIED;
+         err == EWILDNOMATCH || err == EAPPLIED || err == ENOPATCH;
 }
 
 enum
@@ -155,10 +155,10 @@ trigger_one_process(struct ulp_process *target, int retries,
         FATAL("fatal error reverting livepatches (hijacked execution).");
         retry = 0;
       }
-      /* In case we received a `No Target Lib` error, ignore it because we are
-         doing atomic patching and it may be the first patch we are trying to
-         apply.  */
-      if (livepatch && result == ENOTARGETLIB) {
+      /* In case we received a `No Target Lib` or `No patches reverted` error,
+         ignore it because we are doing atomic patching and it may be the
+         first patch we are trying to apply.  */
+      if (livepatch && (result == ENOTARGETLIB || result == ENOPATCH)) {
         result = 0;
       }
 


### PR DESCRIPTION
When reverting all patches with --revert-all of a library that do not have liveatches installed, the `ulp` tool warned the user about this but that is designed behaviour on the first livepatch installation. This commit fixes this.

Closes #180