### PR TITLE
Fix `ulp patches -p PID` crashing when PID do not exist

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -603,7 +603,8 @@ TESTS = \
   user_disable.py \
   group_disable.py \
   mprotect.py \
-  mprotect_patch.py
+  mprotect_patch.py \
+  patches.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/patches.py
+++ b/tests/patches.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2023 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test `ulp patches` command.
+
+import testsuite
+import subprocess
+import sys
+import os
+
+# Check if the ULP tool crashes if -p is passed to unexisting process.
+command = [testsuite.ulptool, "patches", "-p", "99999"]
+try:
+    tool = subprocess.run(command, timeout=10, stderr=subprocess.STDOUT)
+except:
+    exit(1)
+
+if tool.returncode != 0:
+    exit(1)
+
+exit(0)

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -403,7 +403,8 @@ check_preamble(ElfW(Addr) sym_address, pid_t pid)
   if (read_memory((char *)bytes, 2, pid, sym_address)) {
     /* In case it was unable to read the symbol due to permission error, just
      * warn in debug output.  */
-    DEBUG("Unable to read symbol preamble at address %lx in process %d", sym_address, pid);
+    DEBUG("Unable to read symbol preamble at address %lx in process %d",
+          sym_address, pid);
     return false;
   }
 
@@ -617,9 +618,13 @@ insert_target_process(int pid, struct ulp_process **list)
   if (ret) {
     WARN("Failed to parse data for live-patchable process %d: %s", pid,
          libpulp_strerror(ret));
+    free(new);
+    return;
   }
-  new->next = *list;
-  *list = new;
+  else {
+    new->next = *list;
+    *list = new;
+  }
 }
 
 /** @brief Prints all the info collected about the processes in `process_list`.


### PR DESCRIPTION
Previously, the ulp tool crashed when -p is given a pid which do not exist. This commit fixes this.

Closes #186 