### PR TITLE
Enable batch processing with -p PID

### DIFF
--- a/tests/buildid.py
+++ b/tests/buildid.py
@@ -35,10 +35,11 @@ child.expect('Waiting for input.')
 child.sendline('')
 child.expect('1338');
 
-try:
-    child.livepatch('.libs/libbuildid_livepatch1.so')
-except subprocess.CalledProcessError:
-    errorcode = 0
+out = child.livepatch('.libs/libbuildid_livepatch1.so', capture_tool_output=True)
+if out.find("buildid mismatch") == -1:
+  errorcode = 1
+else:
+  errorcode = 0
 
 child.close(force=True)
 exit(errorcode)

--- a/tests/nolibpulp.py
+++ b/tests/nolibpulp.py
@@ -26,7 +26,7 @@ import time
 import testsuite
 from testsuite import ulptool
 
-errorcode = 1
+errorcode = 0
 child = testsuite.spawn('parameters', env=None)
 
 child.expect('Waiting for input.')
@@ -35,10 +35,9 @@ child.sendline('')
 child.expect('1-2-3-4-5-6-7-8');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
-try:
-    child.livepatch('.libs/libparameters_livepatch1.so')
-except subprocess.CalledProcessError:
-    errorcode = 0
+out = child.livepatch('.libs/libparameters_livepatch1.so', capture_tool_output=True)
+if out.find("Libpulp not found in target process") == -1:
+  errorcode = 1
 
 child.sendline('')
 child.expect('1-2-3-4-5-6-7-8', reject='8-7-6-5-4-3-2-1');

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -234,7 +234,7 @@ class spawn(pexpect.spawn):
   # output for more information).
   def livepatch(self, filename=None, timeout=10, retries=1,
                 verbose=True, quiet=False, revert=False, revert_lib=None,
-                sanity=True, prefix=None):
+                sanity=True, prefix=None, capture_tool_output=False):
 
     # Check sanity of command-line arguments
     if sanity is True:
@@ -266,7 +266,11 @@ class spawn(pexpect.spawn):
     # Apply the live patch and check for common errors
     try:
       self.print('Applying/reverting live patch.')
-      tool = subprocess.run(command, timeout=timeout)
+      if capture_tool_output == True:
+          tool = subprocess.run(command, timeout=timeout,
+                                stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+      else:
+          tool = subprocess.run(command, timeout=timeout)
     except subprocess.TimeoutExpired:
       self.print('Live patching timed out.')
       raise
@@ -282,6 +286,11 @@ class spawn(pexpect.spawn):
       self.print('Live patch reverted successfully.')
     else:
       self.print('Live patch applied successfully.')
+
+    if tool.stdout is not None:
+      return tool.stdout.decode()
+    else:
+      return None
 
   # Check if a live patch is already applied. The path to the live patch
   # metadata must be passed through 'filename'. The remaining parameters, which

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -616,7 +616,7 @@ insert_target_process(int pid, struct ulp_process **list)
   ret = initialize_data_structures(new);
   if (ret) {
     WARN("error gathering target process information.");
-    free(new);
+    release_ulp_process(new);
     return;
   }
   else {


### PR DESCRIPTION
Previously, trigger with -p PID runs with batcn processing mode disabled. This may not be desired, as someone could want to install multiple patches into a single process.

Closes #187 