### PR TITLE
Add support for process chrooted into /proc

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -421,7 +421,8 @@ check_PROGRAMS = \
   pcqueue \
   comments \
   block_mprotect \
-  insn_queue
+  insn_queue \
+  chroot
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -559,6 +560,10 @@ insn_queue_SOURCES = insn_queue.c
 insn_queue_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/../include -I$(srcdir)/../tools/include
 insn_queue_LDADD =
 
+chroot_SOURCES = chroot.c
+chroot_CFLAGS = $(AM_CFLAGS)
+chroot_LDADD = libparameters.la
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -610,7 +615,8 @@ TESTS = \
   mprotect_patch.py \
   patches.py \
   mprotect_patch.py \
-  insn_queue.py
+  insn_queue.py \
+  chroot.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/chroot.c
+++ b/tests/chroot.c
@@ -1,0 +1,34 @@
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "libparameters.h"
+
+int
+main(void)
+{
+  char buffer[128];
+
+  if (chroot("/proc")) {
+    /* Permission error, skip the test.  */
+    printf("chroot error\n");
+    return 77;
+  }
+
+  /* Loop waiting for any input. */
+  printf("Waiting for input.\n");
+  while (1) {
+    if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+      if (errno) {
+        perror("chroot");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  }
+
+  return 1;
+}

--- a/tests/chroot.py
+++ b/tests/chroot.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2023 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+import sys
+import os
+
+if os.geteuid() != 0:
+    print("Test not running as root.", file=sys.stdout)
+    exit(77) # Skip test
+
+child = testsuite.spawn('chroot')
+child.expect('Waiting for input.')
+
+child.sendline('')
+child.expect('1-2-3-4-5-6-7-8');
+child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.livepatch('.libs/libparameters_livepatch1.so')
+
+child.sendline('')
+child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
+             reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
+
+child.close(force=True)
+exit(0)

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -203,4 +203,7 @@ get_process_name(struct ulp_process *process)
 
 ulp_error_t get_libpulp_error_state_remote(struct ulp_process *);
 
+const char *adjust_prefix_for_chroot(struct ulp_process *,
+                                     const char *user_prefix);
+
 #endif


### PR DESCRIPTION
Some processes in SLE chroots into /proc. This patch add support for those processes by detecting such cases and escaping the chroot through the root directory of the process with pid = 1.