### PR TITLE
Replace dlsym with ELF file parsing for checking for symbol existence

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -99,10 +99,10 @@ void libpulp_crash_assert_func(const char *file, const char *func, int line,
 
 /** Poison any function that makes the process to abort.  */
 #ifndef DISABLE_ERR_POISON
-# ifdef assert
-#  undef assert
-# endif
-# pragma GCC poison errx exit assert abort
+#ifdef assert
+#undef assert
+#endif
+#pragma GCC poison errx exit assert abort
 #endif
 
 #endif /* ERROR_H  */

--- a/include/insn_queue.h
+++ b/include/insn_queue.h
@@ -29,7 +29,7 @@
 #define INSN_BUFFER_MAX (2 * 1024 * 1024)
 
 /** Define the current version of the instruction queue.  */
-#define INSNQ_CURR_VERSION  1
+#define INSNQ_CURR_VERSION 1
 
 /** The ULP instruction queue.  This works as follows:
  * 1- Libpulp write instructions that should be executed on the `ulp` tool
@@ -50,6 +50,9 @@ struct insn_queue
 
   /** Size in bytes of content.  Must not be larger than INSN_BUFFER_MAX.  */
   int size;
+
+  /** Here to force 8-byte alignment on the buffer.*/
+  int _align;
 
   /** Buffer holding the instructions.  */
   char buffer[INSN_BUFFER_MAX];

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -149,17 +149,17 @@ get_object_metadata(Elf *elf, struct ulp_object *obj)
   return 0;
 }
 
-/** @brief Get offsets of symbols in target library
+/** @brief Check if all symbols in obj is in the info object.
  *
  * This function gather the address of all to-be-patched functions in the
  * target library.
  *
- * @param elf     The target library elf object.
+ * @param info    info object containing the information from elf.
  * @param obj     Chain of objects.
  * @param st1     Symbol table 1, usually .dymsym.
  * @param st2     Symbol table 2, usually .symtab if present.
  *
- * @return 1
+ * @return 1 if success, 0 otherwise.
  */
 int
 get_target_addrs(struct ulp_so_info *info, struct ulp_object *obj)


### PR DESCRIPTION
Previously, a sanity check in the `ulp` tool checking if the symbols declared in the description section is actually in the code section. This check was done by loading the patch with dlopen. However some security flags in openbuildservice introduces a different behaviour on dlopen, turning it unreliable to check this.

Now we parse the file as a ELF and check if the symbol is in the symbol table.