### PR TITLE
Use which to find ulp files when compiling examples

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,7 +39,7 @@ jobs:
       run: zypper -n install autoconf-archive libelf-devel
         python3-pexpect python3-psutil libunwind-devel
         git gcc gcc-c++ clang libtool make dash valgrind gzip
-        findutils libjson-c-devel libseccomp-devel
+        findutils libjson-c-devel libseccomp-devel gawk
     - uses: actions/checkout@v2
     - name: bootstrap
       run: ./bootstrap

--- a/examples/cplusplus/1-class/Makefile
+++ b/examples/cplusplus/1-class/Makefile
@@ -1,7 +1,11 @@
 CXX=g++
 CXXFLAGS=-O2 -fpatchable-function-entry=16,14 -fPIC -g3
-ULP=/usr/bin/ulp
+ULP=$(shell which ulp 2>/dev/null)
 LDFLAGS=
+
+ifeq ($(ULP),)
+$(error Not found ulp, please make install first)
+endif
 
 all: test a_livepatch1.so
 

--- a/examples/cplusplus/2-private_class/Makefile
+++ b/examples/cplusplus/2-private_class/Makefile
@@ -1,7 +1,11 @@
 CXX=g++
 CXXFLAGS=-O2 -fpatchable-function-entry=16,14 -fdump-ipa-clones -fPIC -g3
-ULP=/usr/bin/ulp
+ULP=$(shell which ulp 2>/dev/null)
 LDFLAGS=
+
+ifeq ($(ULP),)
+$(error Not found ulp, please make install first)
+endif
 
 all: test a_livepatch1.so
 

--- a/examples/cplusplus/3-indirect_call/Makefile
+++ b/examples/cplusplus/3-indirect_call/Makefile
@@ -1,7 +1,11 @@
 CXX=g++
 CXXFLAGS=-O2 -fpatchable-function-entry=16,14 -fdump-ipa-clones -fPIC -g3
-ULP=/usr/bin/ulp
+ULP=$(shell which ulp 2>/dev/null)
 LDFLAGS=
+
+ifeq ($(ULP),)
+$(error Not found ulp, please make install first)
+endif
 
 all: test a_livepatch1.so
 

--- a/examples/cplusplus/4-global_var/Makefile
+++ b/examples/cplusplus/4-global_var/Makefile
@@ -1,7 +1,11 @@
 CXX=g++
 CXXFLAGS=-O2 -fpatchable-function-entry=16,14 -fdump-ipa-clones -fPIC -g3
-ULP=/usr/bin/ulp
+ULP=$(shell which ulp 2>/dev/null)
 LDFLAGS=
+
+ifeq ($(ULP),)
+$(error Not found ulp, please make install first)
+endif
 
 all: test a_livepatch1.so
 

--- a/examples/cplusplus/5-queue/Makefile
+++ b/examples/cplusplus/5-queue/Makefile
@@ -1,7 +1,11 @@
 CXX=g++
 CXXFLAGS=-fpatchable-function-entry=16,14 -fdump-ipa-clones -fPIC -g3 -Wno-terminate -O2
-ULP=/usr/bin/ulp
+ULP=$(shell which ulp 2>/dev/null)
 LDFLAGS=
+
+ifeq ($(ULP),)
+$(error Not found ulp, please make install first)
+endif
 
 all: test a_livepatch1.so
 


### PR DESCRIPTION
'configure' set default target installation directory is '/usr/local/bin/ulp', at the same time, ulp could be installed to '/usr/bin/', thus, we should find ulp in examples/*/Makefile, it's better way.