### PR TITLE
New information in `ulp patches`

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -576,3 +576,40 @@ get_process_owner(pid_t pid)
 
   return info.st_uid;
 }
+
+ulp_version_t
+ulp_version_from_string(char *str)
+{
+  ulp_version_t ver[3];
+  char *number;
+
+  for (int i = 0; i < 3; i++) {
+    number = strtok(str, ".");
+    str = NULL;
+    if (!isnumber(number)) {
+      /* Not a number??  */
+      return 0;
+    }
+
+    ver[i] = atoi(number);
+    if (ver[i] > 0xFFFF) {
+      /* Out of bound.  */
+      return 0;
+    }
+  }
+
+  return ULP_VERSION_TRIPLET(ver[0], ver[1], ver[2]);
+}
+
+const char *
+ulp_version_as_string(ulp_version_t ver)
+{
+  static char str[18]; // 65535.65535.65535\0 has 18 bytes;
+  uint16_t a, b, c;
+  a = (ver & 0x0000FFFF00000000) >> 32;
+  b = (ver & 0x00000000FFFF0000) >> 16;
+  c = (ver & 0x000000000000FFFF);
+
+  sprintf(str, "%hu.%hu.%hu", a, b, c);
+  return str;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([libpulp],[0.3.0],[noreply@suse.com])
+AC_INIT([libpulp],[0.3.1],[noreply@suse.com])
 
 # Keep most generated files under the config directory.
 AC_CONFIG_AUX_DIR([config])

--- a/include/ulp_common.h
+++ b/include/ulp_common.h
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 #define OUT_PATCH_NAME "metadata.ulp"
 #define OUT_REVERSE_NAME "reverse.ulp"
@@ -201,6 +202,9 @@ struct ulp_applied_patch
 
   /** Patch dependency.  Not used but kept for backwards compatibility.  */
   struct ulp_dependency *deps;
+
+  /** Timestamp of when patch was loaded.  */
+  time_t timestamp;
 };
 
 struct ulp_applied_unit
@@ -221,6 +225,20 @@ struct ulp_applied_unit
   /** Next in the chain.  */
   struct ulp_applied_unit *next;
 };
+
+/** Libpulp version type.  The tripplet is incoded here, with a maximum value
+    of 65535.65535.65535.  */
+typedef uint64_t ulp_version_t;
+
+/** @brief Construct ulp_version object from string.  Modifies the string
+    content.  */
+ulp_version_t ulp_version_from_string(char *str);
+
+/** Build ulp_version_t from three shorts.  */
+#define ULP_VERSION_TRIPLET(a, b, c) ((c) + ((b) << 16) + ((a) << 32))
+
+/** @brief Construct string from ulp_version object.  */
+const char *ulp_version_as_string(ulp_version_t ver);
 
 /* Functions present in libcommon, linked agaist both libpulp.so and tools.  */
 const char *get_basename(const char *);

--- a/lib/libpulp.versions
+++ b/lib/libpulp.versions
@@ -27,6 +27,7 @@
     __ulp_error_state;
     __ulp_enable_or_disable_patching;
     __ulp_insn_queue;
+    __ulp_version;
   local:
     *;
 };

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -47,6 +47,9 @@ char __ulp_metadata_buffer[ULP_METADATA_BUF_LEN] = { 0 };
 struct ulp_metadata *__ulp_metadata_ref = NULL;
 struct ulp_detour_root *__ulp_root = NULL;
 
+/* current libpulp version.  */
+const char __ulp_version[] = VERSION;
+
 /* clang-format off */
 
 /** Intel endbr64 instruction optcode.  */

--- a/lib/ulp.c
+++ b/lib/ulp.c
@@ -831,6 +831,11 @@ ulp_state_update(struct ulp_metadata *ulp)
     unit = unit->next;
   }
 
+  /* Insert timestamp.  */
+  struct timespec t;
+  clock_gettime(CLOCK_REALTIME, &t);
+  a_patch->timestamp = t.tv_sec;
+
   /* leave last on top of list to optmize revert */
   prev_patch = __ulp_state.patches;
   __ulp_state.patches = a_patch;

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -59,6 +59,7 @@ struct arguments
   int disable_threads;
   int recursive;
   int no_summarization;
+  int only_livepatched;
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   int check_stack;
 #endif

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -117,7 +117,7 @@ struct ulp_dynobj
   Elf64_Addr insn_queue;
 
   /* Version of the libpulp tool running on the target process.  */
-  const char *libpulp_version;
+  ulp_version_t libpulp_version;
 
   /* Version of the insn_queue on target process.  */
   int insn_queue_version;

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -116,6 +116,9 @@ struct ulp_dynobj
   Elf64_Addr enable_disable_patching;
   Elf64_Addr insn_queue;
 
+  /* Version of the libpulp tool running on the target process.  */
+  const char *libpulp_version;
+
   /* Version of the insn_queue on target process.  */
   int insn_queue_version;
   /* end FIXME.  */

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -378,7 +378,11 @@ print_lib_patches(struct ulp_applied_patch *patch, const char *libname)
 
   while (patch) {
     if (!strcmp(libname, patch->lib_name)) {
-      printf("      livepatch: %s\n", get_basename(patch->container_name));
+      struct tm *timeinfo = localtime(&patch->timestamp);
+      printf("      livepatch: %s", get_basename(patch->container_name));
+      if (patch->timestamp != 0) {
+        printf(" loaded on %s", asctime(timeinfo));
+      }
       print_relevant_labels(patch->container_name);
     }
     patch = patch->next;
@@ -566,7 +570,8 @@ print_process(struct ulp_process *process, int print_buildid)
       if (print_buildid)
         printf(" (%s)", buildid_to_string(object_item->build_id));
       if (object_item->libpulp_version) {
-        printf(" (version %s)", object_item->libpulp_version);
+        const char *version = ulp_version_as_string(object_item->libpulp_version);
+        printf(" (version %s)", version);
       }
       printf(":\n");
 

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -552,11 +552,16 @@ print_remote_err_status(struct ulp_process *p)
 }
 
 static void
-print_process(struct ulp_process *process, int print_buildid)
+print_process(struct ulp_process *process, int print_buildid, bool only_livepatched)
 {
   struct ulp_dynobj *object_item;
   pid_t pid = process->pid;
   struct ulp_applied_patch *patch = ulp_read_state(process);
+
+  /* In case the flag `only_patched` is NULL, then skip process.  */
+  if (only_livepatched && patch == NULL) {
+    return;
+  }
 
   printf("PID: %d, name: %s\n", pid, get_process_name(process));
   print_remote_err_status(process);
@@ -646,7 +651,7 @@ print_process_list(struct ulp_process *process_list, int print_buildid)
 
   process_item = process_list;
   while (process_item) {
-    print_process(process_item, print_buildid);
+    print_process(process_item, print_buildid, false);
     process_item = process_item->next;
   }
 }
@@ -655,6 +660,7 @@ int
 run_patches(struct arguments *arguments)
 {
   bool print_build_id = arguments->buildid;
+  bool only_livepatched = arguments->only_livepatched;
   ulp_quiet = arguments->quiet;
   ulp_verbose = arguments->verbose;
   enable_threading = !arguments->disable_threads;
@@ -665,7 +671,7 @@ run_patches(struct arguments *arguments)
 
   FOR_EACH_ULP_PROCESS_FROM_USER_WILDCARD(p, process_wildcard, user_wildcard)
   {
-    print_process(p, print_build_id);
+    print_process(p, print_build_id, only_livepatched);
   }
 
   return 0;

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -547,12 +547,13 @@ print_remote_err_status(struct ulp_process *p)
   change_color(TERM_COLOR_RESET);
 }
 
-void
+static void
 print_process(struct ulp_process *process, int print_buildid)
 {
   struct ulp_dynobj *object_item;
   pid_t pid = process->pid;
   struct ulp_applied_patch *patch = ulp_read_state(process);
+
   printf("PID: %d, name: %s\n", pid, get_process_name(process));
   print_remote_err_status(process);
   printf("  Livepatchable libraries:\n");
@@ -564,6 +565,9 @@ print_process(struct ulp_process *process, int print_buildid)
       printf("    in %s", object_item->filename);
       if (print_buildid)
         printf(" (%s)", buildid_to_string(object_item->build_id));
+      if (object_item->libpulp_version) {
+        printf(" (version %s)", object_item->libpulp_version);
+      }
       printf(":\n");
 
       print_lib_patches(patch, object_item->filename);

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -130,6 +130,7 @@ static const char doc[] =
 #define ULP_OP_DISABLE_THREADING 260
 #define ULP_OP_RECURSIVE 261
 #define ULP_OP_DISABLE_SUMMARIZATION 262
+#define ULP_OP_ONLY_LIVEPATCHED 263
 
 static struct argp_option options[] = {
   { 0, 0, 0, 0, "Options:", 0 },
@@ -142,6 +143,7 @@ static struct argp_option options[] = {
     "Do not launch additional threads", 0 },
   { 0, 0, 0, 0, "dump & patches command only:", 0 },
   { "buildid", 'b', 0, 0, "Print the build id", 0 },
+  { "only-livepatched", ULP_OP_ONLY_LIVEPATCHED, 0, 0, "Print only processes that were livepatched", 0 },
   { 0, 0, 0, 0, "trigger command only:", 0 },
   { "revert-all", ULP_OP_REVERT_ALL, "LIB", 0,
     "Revert all patches from LIB. If LIB=target, then all patches from the "
@@ -358,6 +360,10 @@ parser(int key, char *arg, struct argp_state *state)
 
     case ULP_OP_DISABLE_SUMMARIZATION:
       arguments->no_summarization = 1;
+      break;
+
+    case ULP_OP_ONLY_LIVEPATCHED:
+      arguments->only_livepatched = 1;
       break;
 
     case 'u':


### PR DESCRIPTION
This PR adds mainly three things:
1. The  ` __ulp_version` symbol to libpulp, which is used to determine which version of libpulp the target process is running
2. A new timestamp showing when a livepatch was loaded in the process
3. A new flag `--only-livepatched`, which only shows process that received at least one patch.