### PR TITLE
Check for ptrace_scope before doing ulp operations

### DIFF
--- a/tools/patches.c
+++ b/tools/patches.c
@@ -184,10 +184,11 @@ process_list_end(struct ulp_process_iterator *it)
 {
   if (it->now == NULL) {
     release_ulp_process(it->last);
-    producer_consumer_delete(it->pcqueue);
     if (enable_threading) {
+      /* Make sure the threads stopped before destroying the queue.  */
       pthread_join(process_list_thread, NULL);
     }
+    producer_consumer_delete(it->pcqueue);
 
     /* In case threads were disabled because of some special case, then enable
        it now.  */

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -26,8 +26,12 @@
 #include <sys/ptrace.h>
 #include <sys/user.h>
 #include <sys/wait.h>
+#include <stdbool.h>
 
 #include "ulp_common.h"
+
+/* System configuration options.  */
+bool check_ptrace_scope(void);
 
 /* Memory read/write helper functions */
 


### PR DESCRIPTION
YAMA has a security feature that block ptrace of non-child processes. Check for that when the command is issued to make sure everything will work as it should.
    
