### PR TITLE
Avoid *.specialized.* symbols in process_access test.

### DIFF
--- a/tests/process_access.c
+++ b/tests/process_access.c
@@ -26,9 +26,19 @@
 static char *banner = "Original banner";
 
 /* Noinline must be set, else no calls are issued.  */
-char *__attribute__((noinline)) banner_get(void) { return banner; }
+char *__attribute__((noinline)) banner_get(void) { printf("banner addr: 0x%lx\n", (unsigned long)banner); return banner; }
 
+
+/* Since clang-18 when compiling this function it is broken in two parts:
+   banner_set and banner_set.specialized.1.  We don't want it on this test so
+   we disable optimizations in this test.  */
+#ifdef __clang__
+#pragma clang optimize off
+#endif
 void __attribute__((noinline)) banner_set(char *new) { banner = new; }
+#ifdef __clang__
+#pragma clang optimize on
+#endif
 
 int
 main(void)


### PR DESCRIPTION
clang-18 inserts new *.specialized.* symbols in banner_get and then calls it instead of the original banner_set function.  This is undesired once we livepatch banner_set so disable optimizations in this function.