### PR TITLE
Remove "Unable to get section data." message

### DIFF
--- a/tests/asunsafe_conversion.py
+++ b/tests/asunsafe_conversion.py
@@ -34,7 +34,7 @@ child.expect('hello')
 errors = 0
 try:
   # Apply the live patch.
-  child.livepatch('.libs/libblocked_livepatch1.so', retries=100)
+  child.livepatch('.libs/libblocked_livepatch1.so', retries=2000)
 except subprocess.TimeoutExpired:
   print('Deadlock while live patching - AS-Unsafe conversion not tested')
   # The deadlock test (tests/deadlock) has a far greater chance of

--- a/tools/extract.c
+++ b/tools/extract.c
@@ -265,7 +265,6 @@ get_list_of_symbols_in_section(Elf *elf, Elf_Scn *s)
   nsyms = sh.sh_size / sh.sh_entsize;
   data = elf_getdata(s, NULL);
   if (!data) {
-    WARN("Unable to get section data.");
     return NULL;
   }
 

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -948,33 +948,6 @@ parse_build_id(Elf_Scn *s, char **result, int *length)
   return 0;
 }
 
-void *
-get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search)
-{
-  int nsyms, i;
-  char *sym_name;
-  Elf_Data *data;
-  GElf_Shdr sh;
-  GElf_Sym sym;
-
-  gelf_getshdr(s, &sh);
-
-  nsyms = sh.sh_size / sh.sh_entsize;
-  data = elf_getdata(s, NULL);
-  if (!data) {
-    WARN("Unable to get section data.");
-    return 0;
-  }
-
-  for (i = 0; i < nsyms; i++) {
-    gelf_getsym(data, i, &sym);
-    sym_name = elf_strptr(elf, sh.sh_link, sym.st_name);
-    if (strcmp(sym_name, search) == 0)
-      return (void *)sym.st_value;
-  }
-  return 0;
-}
-
 int
 write_patch_id(struct ulp_metadata *ulp, const char *description,
                const char *livepatch)


### PR DESCRIPTION
This message may happen if library does not contain either .dynsym or .symtab sections, which may happen and is fine. So do not issue an error because of that.