### PR TITLE
Change .so load policy and fix symbol visibility problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ Makefile.in
 configure
 aclocal.m4
 autom4te.cache
+*~
+*.swp
 dev/

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -67,6 +67,7 @@ typedef int ulp_error_t;
 #define ENOPATCH      284 /** No patches installed.  */
 #define EINSNQ        285 /** Instruction queue in inconsistent state.  */
 #define EOLDULP       286 /** ULP tool is too old.  */
+#define EDLOPEN       287 /** Failure in dlopen.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -104,6 +105,7 @@ typedef int ulp_error_t;
     "No patches installed", \
     "Instruction queue in inconsistent state", \
     "ULP tool is too old", \
+    "Failure in dlopen", \
   }
 /* clang-format on */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -198,6 +198,14 @@ libstress_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/libstress.post
 
+libvisibility_la_SOURCES = libvisibility.c
+libvisibility_la_CFLAGS  = $(TARGET_CFLAGS)
+libvisibility_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/libvisibility.post
+
+check_LTLIBRARIES += libvisibility.la
+
 # Live patches
 check_LTLIBRARIES += libdozens_livepatch1.la \
                      libdozens_livepatch99.la \
@@ -224,7 +232,9 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libprefix_livepatch1.la \
                      libmanyprocesses_livepatch1.la \
                      libstress_livepatch1.la \
-                     libcomments_livepatch1.la
+                     libcomments_livepatch1.la \
+                     libvisibility_livepatch1.la \
+                     libvisibility_livepatch2.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -304,6 +314,13 @@ libstress_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libcomments_livepatch1_la_SOURCES = libcomments_livepatch1.c
 libcomments_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libvisibility_livepatch1_la_SOURCES = libvisibility_livepatch1.c
+libvisibility_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+libvisibility_livepatch2_la_SOURCES = libvisibility_livepatch2.c
+libvisibility_livepatch2_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -356,7 +373,11 @@ METADATA = \
   libcomments_livepatch1.dsc \
   libcomments_livepatch1.ulp \
   libstress_livepatch1.dsc \
-  libstress_livepatch1.ulp
+  libstress_livepatch1.ulp \
+  libvisibility_livepatch1.dsc \
+  libvisibility_livepatch1.ulp \
+  libvisibility_livepatch2.dsc \
+  libvisibility_livepatch2.ulp
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -384,7 +405,9 @@ EXTRA_DIST = \
   libprocess_livepatch1.in \
   libprocess_access_livepatch1.in \
   libcomments_livepatch1.in \
-  libstress_livepatch1.in
+  libstress_livepatch1.in \
+  libvisibility_livepatch1.in \
+  libvisibility_livepatch2.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -422,7 +445,8 @@ check_PROGRAMS = \
   comments \
   block_mprotect \
   insn_queue \
-  chroot
+  chroot \
+  visibility
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -564,6 +588,10 @@ chroot_SOURCES = chroot.c
 chroot_CFLAGS = $(AM_CFLAGS)
 chroot_LDADD = libparameters.la
 
+visibility_SOURCES = visibility.c
+visibility_CFLAGS = $(AM_CFLAGS)
+visibility_LDADD = libvisibility.la
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -616,7 +644,8 @@ TESTS = \
   patches.py \
   mprotect_patch.py \
   insn_queue.py \
-  chroot.py
+  chroot.py \
+  visibility.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/libvisibility.c
+++ b/tests/libvisibility.c
@@ -1,0 +1,36 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2024 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This function has hidden visibility.  We should not be able to do an weak
+   externalization here.  */
+
+static char string[] = "This is a hidden string";
+
+__attribute__((visibility("hidden")))
+void *get_hidden_address(void)
+{
+  return string;
+}
+
+void *get_address(void)
+{
+  return get_hidden_address();
+}

--- a/tests/libvisibility_livepatch1.c
+++ b/tests/libvisibility_livepatch1.c
@@ -1,0 +1,33 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2024 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+static char string[128];
+
+void *get_hidden_address(void);
+
+void *get_address_lp(void)
+{
+  strcpy(string, "String from lp ");
+  strcat(string, get_hidden_address());
+  return string;
+}

--- a/tests/libvisibility_livepatch1.in
+++ b/tests/libvisibility_livepatch1.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libvisibility_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libvisibility.so.0.json
+get_hidden_address:get_address_lp

--- a/tests/libvisibility_livepatch2.c
+++ b/tests/libvisibility_livepatch2.c
@@ -1,0 +1,34 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2024 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+static char string[128];
+
+// Strong externalization of get_hidden_address
+static __attribute__((used)) void *(*klpe_get_hidden_address)(void);
+
+void *get_address_lp(void)
+{
+  strcpy(string, "String from lp ");
+  strcat(string, (*klpe_get_hidden_address)());
+  return string;
+}

--- a/tests/libvisibility_livepatch2.in
+++ b/tests/libvisibility_livepatch2.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/libvisibility_livepatch2.so
+@__ABS_BUILDDIR__/.libs/libvisibility.so.0.json
+get_address:get_address_lp
+#get_hidden_address:klpe_get_hidden_address

--- a/tests/visibility.c
+++ b/tests/visibility.c
@@ -1,0 +1,37 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2024 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+void *get_address(void);
+
+int main(void)
+{
+  while (1) {
+    puts("Press ENTER to continue");
+    getchar();
+    const char *string = get_address();
+    puts(string);
+  }
+
+  return 0;
+}

--- a/tests/visibility.py
+++ b/tests/visibility.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2024 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('visibility', script=False)
+
+child.expect('Press ENTER to continue')
+child.sendline('')
+child.expect('This is a hidden string')
+child.expect('Press ENTER to continue')
+out = child.livepatch('.libs/libvisibility_livepatch1.so',
+                sanity=False, capture_tool_output=True)
+
+child.sendline('')
+child.expect('This is a hidden string')
+
+# Check if we can't apply the above patch.
+if out.find('Failure in dlopen') < 0:
+  child.close(force=True)
+  exit(1)
+
+# Now try to apply the patch with strong externalization
+child.expect('Press ENTER to continue')
+child.livepatch('.libs/libvisibility_livepatch2.so')
+
+child.sendline('')
+child.expect('String from lp This is a hidden string')
+
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
Previously, libpulp used RTLD_LAZY in dlopen, which resulted in livepatch that should have failed to apply being applied. In SLE-15-SP4, those patches seems to work regardless of that, but in SP5 it result in problems. Hence, change this policy to RTLD_NOW to force all symbols to be loaded by the linker at patch load time.

Also, this commit now encode the symbol references on packer even if not specified in .dsc by capturing it from the .json dumps, which should improve the support for strong externalizations.