### PR TITLE
Fix livepatching on ppc64le when functions have more than 8 parameters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,8 +241,8 @@ AS_CASE([$target_cpu],
         ],
         [powerpc64le],
         [
-          _NOPS_LEN=17
-          _PRE_NOPS_LEN=16
+          _NOPS_LEN=14
+          _PRE_NOPS_LEN=13
           _LD_LINUX="ld64.so.2"
           _PROC="powerpc64le"
         ]

--- a/include/arch/powerpc64le/arch_common.h
+++ b/include/arch/powerpc64le/arch_common.h
@@ -4,6 +4,33 @@
 /** Offset of TLS pointer.  */
 #define TLS_DTV_OFFSET 0x8000
 
+/* Program load bias, which can be recovered by running `ld --verbose`.  */
+#define EXECUTABLE_START         0x10000000UL
+
+/* The Red zone.  */
+#define RED_ZONE_LEN             512
+
+/**
+ * Number of bytes that the kernel subtracts from the program counter,
+ * when an ongoing syscall gets interrupted and must be restarted.
+ */
+#define RESTART_SYSCALL_SIZE     0
+
+#ifdef __ASSEMBLER__
+/* Declarations that requires assembler.  */
+
+/** Field offset determining the real size (in bytes) of the ulp stack.  */
+#define ULP_STACK_REAL_SIZE       0
+
+/** Field offset determining the used size (in bytes) of the ulp stack.  */
+#define ULP_STACK_USED_SIZE       8
+
+/** Field offset determining the object pointer (allocated by mmap) of the ulp stack.  */
+#define ULP_STACK_PTR             16
+
+#else
+/* Declarations that requires a C compiler.  */
+
 /** Struct used to store the registers in memory.  */
 typedef struct pt_regs registers_t;
 
@@ -19,16 +46,17 @@ typedef struct pt_regs registers_t;
 /** Set the GLOBAL ENTRYPOINT REGISTER, which in power is r12.  */
 #define SET_GLOBAL_ENTRYPOINT_REG(reg, val) (reg).gpr[12] = (val)
 
-/* Program load bias, which can be recovered by running `ld --verbose`.  */
-#define EXECUTABLE_START         0x10000000UL
+/** Field determining the real size (in longs) of the ulp stack.  */
+#define ULP_STACK_REAL_SIZE       0
 
-/* The Red zone.  */
-#define RED_ZONE_LEN             512
+/** Field determining the used size (in longs) of the ulp stack.  */
+#define ULP_STACK_USED_SIZE       1
 
-/**
- * Number of bytes that the kernel subtracts from the program counter,
- * when an ongoing syscall gets interrupted and must be restarted.
- */
-#define RESTART_SYSCALL_SIZE     0
+/** Field determining the object pointer (allocated by mmap) of the ulp stack.  */
+#define ULP_STACK_PTR             2
 
-#endif
+/** The ulp_stack object, defined in ulp_prologue.S.  */
+extern __thread unsigned long ulp_stack[];
+
+#endif /* __ASSEMBLER__ */
+#endif /* _ARCH_PPC64LE_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,6 +1,6 @@
 #   libpulp - User-space Livepatching Library
 #
-#   Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+#   Copyright (C) 2020-2025 SUSE Software Solutions GmbH
 #
 #   This file is part of libpulp.
 #
@@ -47,6 +47,7 @@ endif
 if CPU_PPC64LE
 libpulp_la_SOURCES += \
   arch/powerpc64le/ulp_interface.S \
+  arch/powerpc64le/ulp_prologue.S \
   arch/powerpc64le/patch.c
 
 libpulp_la_LDFLAGS += \
@@ -58,6 +59,7 @@ libpulp_la_DEPENDENCIES= libpulp.versions
 libpulp_la_LIBADD = $(top_builddir)/common/libcommon.la
 
 AM_CFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/include/arch/$(target_cpu)
+AM_CCASFLAGS += -I$(top_srcdir)/include -I$(top_srcdir)/include/arch/$(target_cpu)
 
 # Add -fno-strict-alias to the insn_queue code.
 insn_queue.lo : CFLAGS += -fno-strict-aliasing

--- a/lib/arch/powerpc64le/ulp_prologue.S
+++ b/lib/arch/powerpc64le/ulp_prologue.S
@@ -1,0 +1,229 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2017-2025 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "arch/powerpc64le/arch_common.h"
+
+.file	"ulp_prologue.S"
+.machine power8
+.abiversion 2
+.section	".text"
+.align 2
+.p2align 4,,15
+
+# ulp_stack_helper
+.globl   ulp_stack_helper
+.type    ulp_stack_helper, @function
+
+.section        ".text"
+.align 2
+.p2align 4,,15
+
+# Trampoline routine
+.globl   trampoline_routine
+.type    trampoline_routine, @function
+trampoline_routine:
+	.cfi_startproc
+
+  # Concatenate two registers from prologue.
+  rldimi %r6, %r5, 32, 0
+
+  # Move the target function ptr to control register so we can free r6.
+  mtctr %r6
+
+  # Load the ulp_stack into r3 through r13 (thread local storage ptr)
+  addis %r5, %r13, ulp_stack@tprel@ha
+  addi  %r5, %r5,  ulp_stack@tprel@l
+
+  # Load real_size
+  ld    %r6, ULP_STACK_REAL_SIZE(%r5)   # Load real_size (allocated by mmap)
+  ld    %r5, ULP_STACK_USED_SIZE(%r5)   # Load used_size (currently in use)
+
+  # Check if we have space.
+  cmpd %cr0, %r6, %r5
+  ble   %cr0, .Lexpand_ulp_stack
+
+.Lcontinue_ulp_prologue:
+
+  # Reload the ulp_stack into r3 through r13 (thread local storage ptr)
+  addis %r5, %r13, ulp_stack@tprel@ha
+  addi  %r5, %r5,  ulp_stack@tprel@l
+
+  # Load used_size
+  ld    %r6, ULP_STACK_USED_SIZE(%r5)
+
+  # Update top_of_stack in the struct field.
+  addi  %r6, %r6, 16
+  std   %r6, ULP_STACK_USED_SIZE(%r5)    # Store new used size value.
+
+  # Load stack ptr
+  ld    %r5, ULP_STACK_PTR(%r5)
+
+  # Store TOC
+  add   %r5, %r5, %r6  # ulp_stack + used_size
+  std   %r2, -16(%r5)  # store in *(ulp_stack + used_size - 16)
+
+  # Store LR which we saved on the stack in the prologue. r2 was saved so use it.
+  mflr  %r2
+  std   %r2, -8(%r5)    # store in (ulp_stack + used_size)
+
+  # Restore registers
+  ld    %r5, -8(%r1)  # Restore register.
+  ld    %r6, -16(%r1) # Restore register.
+
+  # Jump to target function
+  mfctr %r12
+  bctrl
+
+  # Load the ulp_stack into r5 through r13 (thread local storage ptr)
+  addis %r5, %r13, ulp_stack@tprel@ha
+  addi  %r5, %r5,  ulp_stack@tprel@l
+
+  # Deference ulp_stack.
+  ld    %r6, ULP_STACK_USED_SIZE(%r5)
+  addi  %r6, %r6, -16   # Sub 16 bytes because the first entry stores the top of stack, and we need to store 2 longs.
+  std   %r6, ULP_STACK_USED_SIZE(%r5)     # Store new used_size value.
+
+  # Load ulp_stack ptr field.
+  ld    %r5, ULP_STACK_PTR(%r5)
+
+  # Restore saved data.
+  ld    %r2, 0(%r5)     # Restore TOC
+  ld    %r8, 8(%r5)     # Restore LR
+  mtlr  %r8             # Load LR
+
+  # Return execution to caller.
+  blr
+
+.Lexpand_ulp_stack:
+
+  # Save all volatile registers
+  std   %r2,  -24(%r1)
+  std   %r3,  -32(%r1)
+  std   %r4,  -40(%r1)
+  std   %r5,  -48(%r1)
+  std   %r6,  -56(%r1)
+  std   %r7,  -64(%r1)
+  std   %r8,  -72(%r1)
+  std   %r9,  -80(%r1)
+  std   %r10, -88(%r1)
+  std   %r11, -96(%r1)
+  std   %r12, -104(%r1)
+  mfctr %r3
+  std   %r3,  -112(%r1)
+  mflr  %r3,
+  std   %r3,  -120(%r1)
+
+  # Move stack register
+  addi  %r1, %r1, -(120 + 32 + 8) # 32 + 8 for padding
+
+  # Fix TOC.  %r12 must be pointing to the address of trampoline_routine.
+  addis %r2,%r12, .TOC.-trampoline_routine@ha
+  addi  %r2,%r2 , .TOC.-trampoline_routine@l
+
+  # Call C helper routine.
+  bl ulp_stack_helper
+  nop
+
+  # Restore stack register.
+  addi  %r1, %r1, (120 + 32 + 8)
+
+  # Restore registers
+  ld    %r3,  -112(%r1)
+  mtctr %r3
+  ld    %r3,  -120(%r1)
+  mtlr  %r3
+  ld    %r2,  -24(%r1)
+  ld    %r3,  -32(%r1)
+  ld    %r4,  -40(%r1)
+  ld    %r5,  -48(%r1)
+  ld    %r6,  -56(%r1)
+  ld    %r7,  -64(%r1)
+  ld    %r8,  -72(%r1)
+  ld    %r9,  -80(%r1)
+  ld    %r10, -88(%r1)
+  ld    %r11, -96(%r1)
+  ld    %r12, -104(%r1)
+
+  b     .Lcontinue_ulp_prologue
+
+	.long 0
+	.byte 0,0,0,0,0,0,0,0
+	.cfi_endproc
+	.size	trampoline_routine,.-trampoline_routine
+
+	.globl ulp_prologue
+	.type  ulp_prologue, @function
+ulp_prologue:
+	.cfi_startproc
+  std   %r5, -8(%r1)  # Save one register used as function parameter
+  std   %r6, -16(%r1) # Save
+
+  # Compute absolute address of trampoline routine
+  lis   %r5,  trampoline_routine@highest     #0x1122
+  ori   %r5,  %r5, trampoline_routine@higher #0x3344
+  lis   %r12, trampoline_routine@high        #0x5566
+  ori   %r12, %r12, trampoline_routine@l      #0x7788
+
+  # Concatenate two registers
+  rldimi %r12, %r5, 32, 0
+
+  # Move to control register
+  mtctr %r12
+
+  # Compute absolute address of target function 0x1122334455667788
+  lis   %r5,      0x1122
+  ori   %r5, %r5, 0x3344
+  lis   %r6,      0x5566
+  ori   %r6, %r6, 0x7788
+
+  # Jump to trampoline_routine
+  bctr
+
+  # Execution is returned to the caller by the trampoline_routine, not here.
+  # so no blr is necessary here.
+
+ulp_prologue_end = .
+	.long 0
+	.byte 0,0,0,0,0,0,0,0
+	.cfi_endproc
+.LFE0:
+	.size ulp_prologue,.-ulp_prologue
+ulp_prologue_padding_end = .
+
+.section      ".data"
+.align        2
+.type         ulp_prologue_size, @object
+.size         ulp_prologue_size, 4
+
+.global ulp_prologue_size
+ulp_prologue_size:
+  .long     ulp_prologue_end - ulp_prologue
+
+# Declare a space in thread local storage for the ulp stack.
+.section  .tbss,"awT",@nobits
+.align 4
+.type ulp_stack, @object
+.size ulp_stack, 32   # 3 unsigned longs, 1 padding.
+.global ulp_stack
+ulp_stack:
+  .zero 32
+
+.section	.note.GNU-stack,"",@progbits

--- a/tests/chroot.c
+++ b/tests/chroot.c
@@ -26,7 +26,7 @@ main(void)
       printf("Reached the end of file; quitting.\n");
       return 0;
     }
-    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    int_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 

--- a/tests/chroot.py
+++ b/tests/chroot.py
@@ -31,13 +31,13 @@ child = testsuite.spawn('chroot')
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libparameters_livepatch1.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 

--- a/tests/libmanyprocesses.c
+++ b/tests/libmanyprocesses.c
@@ -37,9 +37,9 @@
  * reviewed and extended accordingly.
  */
 void
-int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h, i, j);
 }
 
 /*

--- a/tests/libmanyprocesses_livepatch1.c
+++ b/tests/libmanyprocesses_livepatch1.c
@@ -22,9 +22,9 @@
 #include <stdio.h>
 
 void
-new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", j, i, h, g, f, e, d, c, b, a);
 }
 
 void

--- a/tests/libparameters.c
+++ b/tests/libparameters.c
@@ -37,9 +37,9 @@
  * reviewed and extended accordingly.
  */
 void
-int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h, i, j);
 }
 
 /*

--- a/tests/libparameters.h
+++ b/tests/libparameters.h
@@ -19,7 +19,8 @@
  *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-void int_params(int a, int b, int c, int d, int e, int f, int g, int h);
+void int_params(int a, int b, int c, int d, int e, int f, int g, int h,
+                int i, int j);
 
 void float_params(float a, float b, float c, float d, float e, float f,
                   float g, float h, float i, float j);

--- a/tests/libparameters_livepatch1.c
+++ b/tests/libparameters_livepatch1.c
@@ -22,9 +22,9 @@
 #include <stdio.h>
 
 void
-new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", j, i, h, g, f, e, d, c, b, a);
 }
 
 void

--- a/tests/libparameters_livepatch3.c
+++ b/tests/libparameters_livepatch3.c
@@ -22,9 +22,9 @@
 #include <stdio.h>
 
 void
-new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", j, i, h, g, f, e, d, c, b, a);
 }
 
 void

--- a/tests/libprocess_livepatch1.c
+++ b/tests/libprocess_livepatch1.c
@@ -22,9 +22,9 @@
 #include <stdio.h>
 
 void
-new_int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+new_int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", h, g, f, e, d, c, b, a);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", j, i, h, g, f, e, d, c, b, a);
 }
 
 void

--- a/tests/libpulp_messages.py
+++ b/tests/libpulp_messages.py
@@ -26,7 +26,7 @@ child = testsuite.spawn('parameters')
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 try:

--- a/tests/manyprocesses.c
+++ b/tests/manyprocesses.c
@@ -22,7 +22,8 @@
 #include <errno.h>
 #include <stdio.h>
 
-void int_params(int a, int b, int c, int d, int e, int f, int g, int h);
+void int_params(int a, int b, int c, int d, int e, int f, int g, int h,
+                int i, int j);
 
 void float_params(float a, float b, float c, float d, float e, float f,
                   float g, float h, float i, float j);
@@ -43,7 +44,7 @@ main(void)
       printf("Reached the end of file; quitting.\n");
       return 0;
     }
-    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    int_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 

--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -43,7 +43,7 @@ if output.find("Processes patched: 3, Skipped: 0, Failed: 0") == -1:
 
 for child in childs:
     child.sendline('')
-    child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+    child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
     child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
                  reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
@@ -51,7 +51,7 @@ testsuite.childless_livepatch(wildcard=None, verbose=True, revert_lib='libmanypr
 
 for child in childs:
     child.sendline('')
-    child.expect('1-2-3-4-5-6-7-8', reject='8-7-6-5-4-3-2-1');
+    child.expect('1-2-3-4-5-6-7-8-9-10', reject='10-9-8-7-6-5-4-3-2-1');
     child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0',
                  reject='10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0');
 

--- a/tests/mprotect_patch.py
+++ b/tests/mprotect_patch.py
@@ -32,20 +32,20 @@ else:
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libparameters_livepatch1.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libparameters_livepatch1.so', revert=True)
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0',
              reject='10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0');
 

--- a/tests/nolibpulp.py
+++ b/tests/nolibpulp.py
@@ -32,7 +32,7 @@ child = testsuite.spawn('parameters', env=None)
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 out = child.livepatch('.libs/libparameters_livepatch1.so', capture_tool_output=True)
@@ -40,7 +40,7 @@ if out.find("Libpulp not found in target process") == -1:
   errorcode = 1
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8', reject='8-7-6-5-4-3-2-1');
+child.expect('1-2-3-4-5-6-7-8-9-10', reject='10-9-8-7-6-5-4-3-2-1');
 
 child.close(force=True)
 exit(errorcode)

--- a/tests/parameters.c
+++ b/tests/parameters.c
@@ -40,7 +40,7 @@ main(void)
       printf("Reached the end of file; quitting.\n");
       return 0;
     }
-    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    int_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 

--- a/tests/parameters.py
+++ b/tests/parameters.py
@@ -26,13 +26,13 @@ child = testsuite.spawn('parameters')
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libparameters_livepatch1.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 

--- a/tests/process.c
+++ b/tests/process.c
@@ -23,9 +23,9 @@
 #include <stdio.h>
 
 __attribute__((noinline)) void
-int_params(int a, int b, int c, int d, int e, int f, int g, int h)
+int_params(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
 {
-  printf("%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h);
+  printf("%d-%d-%d-%d-%d-%d-%d-%d-%d-%d\n", a, b, c, d, e, f, g, h, i, j);
 }
 
 __attribute__((noinline)) void
@@ -52,7 +52,7 @@ main(void)
       printf("Reached the end of file; quitting.\n");
       return 0;
     }
-    int_params(1, 2, 3, 4, 5, 6, 7, 8);
+    int_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   }
 

--- a/tests/process.py
+++ b/tests/process.py
@@ -26,13 +26,13 @@ child = testsuite.spawn('process', script=False)
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libprocess_livepatch1.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 

--- a/tests/process_revert.py
+++ b/tests/process_revert.py
@@ -26,20 +26,20 @@ child = testsuite.spawn('process', script=False)
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libprocess_livepatch1.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libprocess_livepatch1.so', revert=True)
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.close(force=True)

--- a/tests/relative_path.py
+++ b/tests/relative_path.py
@@ -26,13 +26,13 @@ child = testsuite.spawn('parameters')
 child.expect('Waiting for input.')
 
 child.sendline('')
-child.expect('1-2-3-4-5-6-7-8');
+child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 
 child.livepatch('.libs/libparameters_livepatch3.so')
 
 child.sendline('')
-child.expect('8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8');
+child.expect('10-9-8-7-6-5-4-3-2-1', reject='1-2-3-4-5-6-7-8-9-10');
 child.expect('10.0-9.0-8.0-7.0-6.0-5.0-4.0-3.0-2.0-1.0',
              reject='1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');
 

--- a/tests/syscall_restart.c
+++ b/tests/syscall_restart.c
@@ -75,7 +75,7 @@ main(void)
     return 1; /* The test driver is not expected to send EOF. */
   }
 
-  int_params(1, 2, 3, 4, 5, 6, 7, 8);
+  int_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   float_params(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
   return 0; /* At least one byte was read. */
 }


### PR DESCRIPTION
This commit fixes a bug in libpulp where functions with more than 8
parameters could not be livepatched due to a stack corruption.  This
fix is done by introducing a new prologue in ppc64le, together with
an ulp stack to save data (TOC and LR registers) while redirecting
the function.

Closes #217