### PR TITLE
Fix typo in manpage

### DIFF
--- a/man/ulp.1
+++ b/man/ulp.1
@@ -526,7 +526,7 @@ informations into a JSON file specified by
 .PP
 .TP
 .SH EXIT STATUS
-.TPut
+.TP
 exits 0 on success, anything else on error.
 
 .\"-------------------------------------------


### PR DESCRIPTION
Relevant groff warning:

    groff-message troff:<standard input>:529:
    warning: macro 'TPut' not defined (possibly missing space after 'TP')
    [usr/share/man/man1/ulp.1.gz:1]