### PR TITLE
Improve error message when ptrace_scope is enabled

### DIFF
--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -507,9 +507,9 @@ main(int argc, char **argv, char *envp[] __attribute__((unused)))
   /* Check if command requires ptrace.  */
   if (requires_ptrace(arguments.command) &&
         check_ptrace_scope() == false) {
-    WARN("System has 'ptrace_scope' enabled. Please become root or disable it"
+    WARN("System has 'ptrace_scope' enabled. Please become root or disable it "
          "by setting:\n\n"
-         "$ sudo echo 0 > /proc/sys/kernel/yama/ptrace_scope\n\n"
+         "$ echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope\n\n"
          "and try again.");
     return EPERM;
   }


### PR DESCRIPTION
The suggested command-line doesn't work if the user is not logged as root.  Hence provide another that works even if logged as an ordinary user with sudo privileges.