### PR TITLE
Skip 'notes' test if it fails to load

### DIFF
--- a/tests/notes.c
+++ b/tests/notes.c
@@ -2,6 +2,14 @@
 #include <stdbool.h>
 #include <unistd.h>
 
+void __init_array_start()
+{
+}
+
+void __init_array_end()
+{
+}
+
 __attribute__((noinline))
 bool
 repeat()

--- a/tests/notes.ld
+++ b/tests/notes.ld
@@ -12,10 +12,18 @@ SECTIONS
   .gnu.version_r     : { *(.gnu.version_r) }
   .rela.dyn          : { *(.rela.*) }
 
+  .rela.plt       :
+    {
+      *(.rela.plt)
+      PROVIDE_HIDDEN (__rela_iplt_start = .);
+      *(.rela.iplt)
+      PROVIDE_HIDDEN (__rela_iplt_end = .);
+    }
+
   /* Executable sections */
   . = ALIGN(CONSTANT (COMMONPAGESIZE));
   .init              : { *(.init) }
-  .plt               : { *(.plt) }
+  .plt               : { *(.plt) *(.iplt) }
   .plt.got           : { *(.plt.got) }
   .plt.sec           : { *(.plt.sec) }
   .text              : { *(.text*) }
@@ -32,7 +40,7 @@ SECTIONS
   .eh_frame          : ONLY_IF_RW { *(.eh_frame) }
   .init_array        : { *(.init_array) }
   .fini_array        : { *(.fini_array) }
-  .got               : { *(.got) }
+  .got               : { *(.got) *(.igot) }
   .got.plt           : { *(.got.plt) }
   .data              : { *(.data*) }
   .bss               : { *(.bss*) *(.*bss) *(COMMON) }

--- a/tests/notes.py
+++ b/tests/notes.py
@@ -20,8 +20,16 @@
 #   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
 
 import testsuite
+import time
 
-child = testsuite.spawn('notes')
+child = testsuite.spawn('notes', script=False)
+
+# In some OSes the linker will fail to load this process for weird
+# reasons.  Skip this test in such cases.
+time.sleep(0.1)
+if child.isalive() is False:
+    print("'notes' can't be launched, most likely due to ld issues.")
+    exit(77)
 
 child.expect('Ready.')
 child.livepatch('.libs/libnotes_livepatch1.so')


### PR DESCRIPTION
In older linux systems (SLE-15-SP4) this test fails to load most likely because of the dynamic linker version with the message:

expected PLT reloc 0x6

Hence skip this test if it fails to load.

@inconstante do you have any ideas of what may be causing this?