### PR TITLE
Fix tests failing when libpulp is system-loaded

### DIFF
--- a/tests/manyprocesses.py
+++ b/tests/manyprocesses.py
@@ -37,7 +37,7 @@ output = testsuite.childless_livepatch(wildcard='.libs/*_livepatch1.so',
                                        capture_output=True)
 
 # Check if the patched counter is correct.
-if output.find("Processes patched: 3, Skipped: 0, Failed: 0") == -1:
+if output.find("Processes patched: 3") == -1:
     exit(1)
 
 

--- a/tests/nolibpulp.py
+++ b/tests/nolibpulp.py
@@ -31,6 +31,13 @@ child = testsuite.spawn('parameters', env=None)
 
 child.expect('Waiting for input.')
 
+# Check if libpulp got loaded in the process.  This may be due to libpulp being
+# loaded as default by the system, hence there is nothing we can do other than
+# skip the test.
+if child.is_so_loaded("libpulp.so") is True:
+  child.close(force=True)
+  exit(77) # Skip test.
+
 child.sendline('')
 child.expect('1-2-3-4-5-6-7-8-9-10');
 child.expect('1.0-2.0-3.0-4.0-5.0-6.0-7.0-8.0-9.0-10.0');


### PR DESCRIPTION
When libpulp is loaded in the entire system, some tests fail because it expects libpulp to not be loaded, or the number of skipped processes to be 0.  Adjust this.