### PR TITLE
Correcting pointer access to top of stack on restoring LR/TOC

### DIFF
--- a/lib/arch/powerpc64le/ulp_prologue.S
+++ b/lib/arch/powerpc64le/ulp_prologue.S
@@ -110,6 +110,10 @@ trampoline_routine:
   # Load ulp_stack ptr field.
   ld    %r5, ULP_STACK_PTR(%r5)
 
+  # Point to the top of stack but two, these two entries are popped in
+  # previous step and accessed in next step (stack size decremented before access).
+  add   %r5, %r5, %r6  # ulp_stack + used_size
+
   # Restore saved data.
   ld    %r2, 0(%r5)     # Restore TOC
   ld    %r8, 8(%r5)     # Restore LR


### PR DESCRIPTION
The current implementation always retrieves the deepest LR and TOC (belonging to very first patch) from the stack. Since, r5 contains base of stack and "decremented USED_SIZE" is not added to it to point to top of stack, so r5 keep pointing to bottom when retrieving LR/TOC values for any patched function.