### PR TITLE
Improve linker script used by the notes test case

### DIFF
--- a/tests/notes.ld
+++ b/tests/notes.ld
@@ -10,6 +10,7 @@ SECTIONS
   .gnu.version       : { *(.gnu.version) }
   .gnu.version_d     : { *(.gnu.version_d) }
   .gnu.version_r     : { *(.gnu.version_r) }
+  .rela.plt          : { *(.rela.plt) }
   .rela.dyn          : { *(.rela.*) }
 
   /* Executable sections */
@@ -30,8 +31,18 @@ SECTIONS
   /* Read-write sections */
   . = ALIGN(CONSTANT (COMMONPAGESIZE));
   .eh_frame          : ONLY_IF_RW { *(.eh_frame) }
-  .init_array        : { *(.init_array) }
-  .fini_array        : { *(.fini_array) }
+  .init_array        :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    *(.init_array.*)
+    PROVIDE_HIDDEN (__init_array_end = .);
+  }
+  .fini_array        :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    *(.fini_array.*)
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  }
   .got               : { *(.got) }
   .got.plt           : { *(.got.plt) }
   .data              : { *(.data*) }


### PR DESCRIPTION
The linker script used in the notes test case is a simplified version of default linker scripts in the rolling release versions of debian (sid) and opensuse (tumbleweed). The linker script has been tested to work with these distros, but not with others, such as SLE 15 (SP4). Other distros have different linker scripts that fulfill requirements of their toolchains, such as the presence of special symbols.

In the case of SLE 15 SP4, the following symbols are automatically defined by their default linker script:

    __init_array_start
    __init_array_end

however, our manually crafted linker script does not create them, and the compilation of the test case fails with the following error:

    libtool: link: gcc -fpatchable-function-entry=16,14 -Wall -Wextra -Werror
                       -o notes notes-notes.o -g -O2 -I/usr/include/libseccomp/
                       -Wl,--hash-style=gnu -Wl,-T./notes.ld
    ld: /usr/lib64/libc_nonshared.a(elf-init.oS): in function `__libc_csu_init':
    glibc-2.31/csu/elf-init.c:86: undefined reference to `__init_array_start'
    ld: glibc-2.31/csu/elf-init.c:86: undefined reference to `__init_array_end'
    ld: notes: hidden symbol `__init_array_end' isn't defined
    ld: final link failed: bad value

This compilation error is fixed by the changes to the .init_array and .fini_array in this patch.

This change is not enough, however, since the runtime linker also depends on the presence sections that are messed up by our linker script. The problem manifests itself as an error during process initialization, with the following error message:

    tests/notes: error while loading shared libraries:
                 unexpected PLT reloc type 0x06

This is fixed by placing the input section .rela.plt in their own output section, instead of merging it into .rela.dyn.

Suggested-by: Giuliano Belinassi <gbelinassi@suse.de>