### PR TITLE
 Correcting pointer access to top of stack on restoring LR/TOC

### DIFF
--- a/lib/arch/powerpc64le/ulp_prologue.S
+++ b/lib/arch/powerpc64le/ulp_prologue.S
@@ -110,6 +110,10 @@ trampoline_routine:
   # Load ulp_stack ptr field.
   ld    %r5, ULP_STACK_PTR(%r5)
 
+  # Point to the top of stack but two, these two entries are popped in
+  # previous step and accessed in next step (stack size decremented before access).
+  add   %r5, %r5, %r6  # ulp_stack + used_size
+
   # Restore saved data.
   ld    %r2, 0(%r5)     # Restore TOC
   ld    %r8, 8(%r5)     # Restore LR

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,6 +74,16 @@ librecursion_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
 
 POST_PROCESS += .libs/librecursion.post
 
+# Target libraries to test recursion2
+check_LTLIBRARIES += librecursion2.la
+noinst_HEADERS += librecursion2.h
+
+librecursion2_la_SOURCES = librecursion2.c
+librecursion2_la_CFLAGS = $(TARGET_CFLAGS)
+librecursion2_la_LDFLAGS = $(TARGET_LDFLAGS) $(CONVENIENCE_LDFLAGS)
+
+POST_PROCESS += .libs/librecursion2.post
+
 # Target libraries to test live patches blocked in threads
 check_LTLIBRARIES += libblocked.la
 noinst_HEADERS += libblocked.h
@@ -219,6 +229,7 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libparameters_livepatch3.la \
                      libprocess_livepatch1.la \
                      librecursion_livepatch1.la \
+                     librecursion2_livepatch1.la \
                      libblocked_livepatch1.la \
                      libpagecross_livepatch1.la \
                      libaddress_livepatch1.la \
@@ -272,6 +283,9 @@ libprocess_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 librecursion_livepatch1_la_SOURCES = librecursion_livepatch1.c
 librecursion_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
+librecursion2_livepatch1_la_SOURCES = librecursion2_livepatch1.c
+librecursion2_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
 libblocked_livepatch1_la_SOURCES = libblocked_livepatch1.c
 libblocked_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -347,6 +361,8 @@ METADATA = \
   libparameters_livepatch3.ulp \
   librecursion_livepatch1.dsc \
   librecursion_livepatch1.ulp \
+  librecursion2_livepatch1.dsc \
+  librecursion2_livepatch1.ulp \
   libblocked_livepatch1.dsc \
   libblocked_livepatch1.ulp \
   libpagecross_livepatch1.dsc \
@@ -396,6 +412,7 @@ EXTRA_DIST = \
   libparameters_livepatch2.in \
   libparameters_livepatch3.in \
   librecursion_livepatch1.in \
+  librecursion2_livepatch1.in \
   libblocked_livepatch1.in \
   libpagecross_livepatch1.in \
   libaddress_livepatch1.in \
@@ -424,6 +441,7 @@ check_PROGRAMS = \
   numserv_bsymbolic \
   parameters \
   recursion \
+  recursion2 \
   blocked \
   deadlock \
   asunsafe_conversion \
@@ -487,6 +505,10 @@ syscall_restart_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 recursion_SOURCES = recursion.c
 recursion_LDADD = librecursion.la
 recursion_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
+
+recursion2_SOURCES = recursion2.c
+recursion2_LDADD = librecursion2.la
+recursion2_DEPENDENCIES = $(POST_PROCESS) $(METADATA)
 
 blocked_SOURCES = blocked.c
 blocked_CFLAGS = -pthread $(AM_CFLAGS)
@@ -623,6 +645,7 @@ TESTS = \
   numserv_bsymbolic.py \
   parameters.py \
   recursion.py \
+  recursion2.py \
   blocked.py \
   deadlock.py \
   asunsafe_conversion.py \

--- a/tests/librecursion2.c
+++ b/tests/librecursion2.c
@@ -1,0 +1,46 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <librecursion2.h>
+
+long long int __attribute__((noinline))
+func_1(long long int n)
+{
+  if (n < 0)
+    return 0;
+
+  return n + func_2(n-1);
+}
+
+long long int __attribute__((noinline))
+func_2(long long int n)
+{
+  if (n < 0)
+    return 0;
+
+  return 2*n + func_1(n-1);
+}
+
+long long int __attribute__((noinline))
+recursion(long long int n)
+{
+  return func_1(n);
+}

--- a/tests/librecursion2.h
+++ b/tests/librecursion2.h
@@ -1,0 +1,26 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+long long int func_1(long long int n);
+
+long long int func_2(long long int n);
+
+long long int recursion(long long int n);

--- a/tests/librecursion2_livepatch1.c
+++ b/tests/librecursion2_livepatch1.c
@@ -1,0 +1,40 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <librecursion2.h>
+
+long long int __attribute__((noinline))
+new_func_1(long long int n)
+{
+  if (n < 0)
+    return 0;
+
+  return -n + func_2(n-1);
+}
+
+long long int __attribute__((noinline))
+new_func_2(long long int n)
+{
+  if (n < 0)
+    return 0;
+
+  return -2*n + func_1(n-1);
+}

--- a/tests/librecursion2_livepatch1.in
+++ b/tests/librecursion2_livepatch1.in
@@ -1,0 +1,4 @@
+__ABS_BUILDDIR__/.libs/librecursion2_livepatch1.so
+@__ABS_BUILDDIR__/.libs/librecursion2.so.0
+func_1:new_func_1
+func_2:new_func_2

--- a/tests/recursion2.c
+++ b/tests/recursion2.c
@@ -1,0 +1,54 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <librecursion2.h>
+
+int
+main(void)
+{
+  char buffer[128];
+  int input;
+
+  /* Loop waiting for a numerical input. */
+  printf("Waiting for input.\n");
+  while (1) {
+    if (fgets(buffer, sizeof(buffer), stdin) == NULL) {
+      if (errno) {
+        perror("recursive");
+        return 1;
+      }
+      printf("Reached the end of file; quitting.\n");
+      return 0;
+    }
+    input = atoi(buffer);
+    if (input <= 0) {
+      printf("Input must be greater than zero.\n");
+      continue;
+    }
+    printf("%lld\n", recursion(input));
+  }
+
+  return 1;
+}

--- a/tests/recursion2.py
+++ b/tests/recursion2.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2025 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn('recursion2', timeout=60)
+
+child.expect('Waiting for input.')
+
+child.sendline('2')
+child.expect('4');
+
+child.sendline('40')
+child.expect('1220');
+
+child.livepatch('.libs/librecursion2_livepatch1.so')
+
+child.sendline('2')
+child.expect('4');
+
+child.sendline('40')
+child.expect('-1220', reject='1220');
+
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
Correcting pointer access to top of stack

The current implementation always retrieves the deepest LR and TOC (belonging to very first patch) from the stack. Since, r5 contains base of stack and "decremented USED_SIZE" is not added to point to top of stack, so r5 keep pointing to bottom when retrieving LR/TOC values for any patched function.

Authored-by: [dubeyabhishek](https://github.com/dubeyabhishek)