### PR TITLE
Fix dynobj parsing from the `ulp` tool side

### DIFF
--- a/include/arch/powerpc64le/arch_common.h
+++ b/include/arch/powerpc64le/arch_common.h
@@ -4,9 +4,6 @@
 /** Offset of TLS pointer.  */
 #define TLS_DTV_OFFSET 0x8000
 
-/* Program load bias, which can be recovered by running `ld --verbose`.  */
-#define EXECUTABLE_START         0x10000000UL
-
 /* The Red zone.  */
 #define RED_ZONE_LEN             512
 

--- a/include/arch/x86_64/arch_common.h
+++ b/include/arch/x86_64/arch_common.h
@@ -22,9 +22,6 @@ typedef struct user_regs_struct registers_t;
 /** Set the GLOBAL ENTRYPOINT REGISTER, which in x86_64 doesn't exist.  */
 #define SET_GLOBAL_ENTRYPOINT_REG(reg, val)
 
-/** Program load bias, which can be recovered by running `ld --verbose`.  */
-#define EXECUTABLE_START      0x400000UL
-
 /** The red zone.  */
 #define RED_ZONE_LEN          128
 

--- a/tests/notes.py
+++ b/tests/notes.py
@@ -22,11 +22,6 @@
 import testsuite
 import platform
 
-if platform.processor() == 'ppc64le':
-  # Skip this test on ppc64le, as for some reason the build id of the
-  # main process is not found by libpulp.
-  exit(77)
-
 child = testsuite.spawn('notes')
 
 child.expect('Ready.')

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -205,6 +205,8 @@ get_process_name(struct ulp_process *process)
   return get_basename(process->dynobj_main->filename);
 }
 
+ElfW(Addr) get_ehdr_addr(struct ulp_process *, struct ulp_dynobj *);
+
 ulp_error_t get_libpulp_error_state_remote(struct ulp_process *);
 
 const char *adjust_prefix_for_chroot(struct ulp_process *,


### PR DESCRIPTION
The powerpc64le port exposed a bug in `parse_dynobj_elf_headers` that made it compute wrong addresses of objects that were not loaded shared objects (like the main executable for instance).  This commit fixes this problem, hence making the `notes` test work on powerpc64le.

This also eliminates the necessity of having a hardcodede EXECUTABLE_START constant, as custom linkscript binaries may change this value after all.

Closes #235 