### PR TITLE
Optimizing ulp_stack allocation approach

### DIFF
--- a/lib/arch/powerpc64le/patch.c
+++ b/lib/arch/powerpc64le/patch.c
@@ -259,8 +259,8 @@ void ulp_stack_helper(void)
   /* Storage depleted, allocate a new stack.  */
   unsigned long old_size = ulp_stack[ULP_STACK_REAL_SIZE];
 
-  /* Setup new size.  */
-  ulp_stack[ULP_STACK_REAL_SIZE] += 32;
+  /* Setup new stack size. Increase by PAGESIZE to be optimal */
+  ulp_stack[ULP_STACK_REAL_SIZE] += sysconf(_SC_PAGESIZE);
   ulp_stack[ULP_STACK_REAL_SIZE] *= 2;
 
   void *old = (void *)ulp_stack[ULP_STACK_PTR];


### PR DESCRIPTION
   For the mmap() call with addr=NULL and size < PAGE_SIZE, mmap() reserves a page and
   returns the page-aligned address. If ulp_stack_size is set to less than PAGE_SIZE,
   we are under-utilizing the page and need stack resizing with just a few patches per
   threads. However, if patched functions are invoked in hot path, stack resizing cost
   is significant when sum over all threads. In a system with high memory pressure,
   patching may fail as result of failed mmap() call to resize.

   We can reduce the resizing cost by utilizing the complete page rather than just a
   part of it for the stack. Increasing the stack_size by the system page size becomes
   the optimal approach, avoiding frequent stack resizing.

   For eg: On ppc64le, configured with a 64K page size, stack resizing would be required
   after applying 32K patches to a particular thread.