### PR TITLE
ppc64le: rewrite ASM code to not generate TEXTREL

### DIFF
--- a/lib/arch/powerpc64le/patch.c
+++ b/lib/arch/powerpc64le/patch.c
@@ -249,8 +249,10 @@ ulp_pthread_key_init(void)
  * In the ulp prologue in ppc64le we need to save the TOC and LR registers
  * before redirect into a new function, and we store it in a stack allocated
  * by mmap.  This routine does exactly this.
+ *
+ * @return  The address of the ulp_stack object.
  */
-void ulp_stack_helper(void)
+void *ulp_stack_helper(void)
 {
   /* Comparison should have been done in trampoline_routine (this function
      caller), so just assert it here.  */
@@ -276,7 +278,7 @@ void ulp_stack_helper(void)
     /* In this case the system is out of memory...  And there is nothing
        we can do.  */
     libpulp_crash("libpulp: mmap returned -1, application can not continue\n");
-    return;
+    return ulp_stack;
   }
 
   /* In case we have a previous allocated buffer, then copy this.  */
@@ -304,4 +306,6 @@ void ulp_stack_helper(void)
   /* Setup destructor for mmap memory, so we don't leak memory when a thread
      is destroyed.  */
   pthread_once(&ulp_once_control, ulp_pthread_key_init);
+
+  return ulp_stack;
 }

--- a/lib/arch/powerpc64le/ulp_prologue.S
+++ b/lib/arch/powerpc64le/ulp_prologue.S
@@ -32,6 +32,10 @@
 .globl   ulp_stack_helper
 .type    ulp_stack_helper, @function
 
+# __tls_get_addr
+.globl   __tls_get_addr
+.type    __tls_get_addr, @function
+
 .section        ".text"
 .align 2
 .p2align 4,,15
@@ -40,7 +44,7 @@
 .globl   trampoline_routine
 .type    trampoline_routine, @function
 trampoline_routine:
-	.cfi_startproc
+  .cfi_startproc
 
   # Concatenate two registers from prologue.
   rldimi %r6, %r5, 32, 0
@@ -48,36 +52,67 @@ trampoline_routine:
   # Move the target function ptr to control register so we can free r6.
   mtctr %r6
 
-  # Load the ulp_stack into r5 through r13 (thread local storage ptr)
-  addis %r5, %r13, ulp_stack@tprel@ha
-  addi  %r5, %r5,  ulp_stack@tprel@l
+  # Save all volatile registers
+  # r5 & r6 are designated temp regs, having data already on stack.
+  # After return from expand_ulp_stack, both regs construct values
+  # before use.
+  std   %r2,  -24(%r1)
+  std   %r3,  -32(%r1)
+  std   %r12, -40(%r1)
+  mflr  %r2
+  std   %r2,  -48(%r1)
 
-  # Load real_size
-  ld    %r6, ULP_STACK_REAL_SIZE(%r5)   # Load real_size (allocated by mmap)
-  ld    %r5, ULP_STACK_USED_SIZE(%r5)   # Load used_size (currently in use)
+  # Move stack register
+  addi  %r1, %r1, -(48 + 32 + 8) # 32 + 8 for padding
 
-  # Check if we have space.
-  cmpd %cr0, %r6, %r5
+  # Fix TOC.  %r12 must be pointing to the address of trampoline_routine.
+  addis %r2,%r12, .TOC.-trampoline_routine@ha
+  addi  %r2,%r2 , .TOC.-trampoline_routine@l
+
+  # Load ulp_stack
+  addis %r3, %r2, ulp_stack@got@tlsgd@ha
+  addi  %r3, %r3, ulp_stack@got@tlsgd@l
+
+  # Get address of ulp_stack
+  bl    __tls_get_addr(ulp_stack@tlsgd)
+  nop
+
+  # Load ulp_stack attributes
+  ld    %r6, ULP_STACK_REAL_SIZE(%r3)     # Load real_size (allocated by mmap)
+  ld    %r5, ULP_STACK_USED_SIZE(%r3)     # Load used_size
+
+  # Check if we have space
+  cmpd  %cr0, %r6, %r5
   ble   %cr0, .Lexpand_ulp_stack
 
 .Lcontinue_ulp_prologue:
 
-  # Reload the ulp_stack into r5 through r13 (thread local storage ptr)
-  addis %r5, %r13, ulp_stack@tprel@ha
-  addi  %r5, %r5,  ulp_stack@tprel@l
+  # Here we must ensure that %r3 points to ulp_stack.  If we are here from
+  # the .Lexpand_ulp_stack, then r3 will point to it because
+  # ulp_stack_helper returned it.
 
   # Load used_size
-  ld    %r6, ULP_STACK_USED_SIZE(%r5)
+  ld    %r6, ULP_STACK_USED_SIZE(%r3)
 
   # Update top_of_stack in the struct field.
   addi  %r6, %r6, 16
-  std   %r6, ULP_STACK_USED_SIZE(%r5)    # Store new used size value.
+  std   %r6, ULP_STACK_USED_SIZE(%r3)    # Store new used size value.
 
   # Load stack ptr
-  ld    %r5, ULP_STACK_PTR(%r5)
+  ld    %r5, ULP_STACK_PTR(%r3)
 
   # Store TOC
-  add   %r5, %r5, %r6  # ulp_stack + used_size
+  add   %r5, %r5, %r6  # ulp_stack_ptr + used_size
+
+  # Restore stack register.
+  addi  %r1, %r1, (48 + 32 + 8)
+
+  # Load original LR
+  ld    %r2, -48(%r1)
+  mtlr  %r2
+
+  # Load original TOC
+  ld    %r6, -24(%r1)
 
   # At this point, %r5 points to 16 bytes ahead of the slot where we shall
   # save TOC.  Hence we have to subtract 16 bytes of the storing location,
@@ -86,29 +121,55 @@ trampoline_routine:
   # +----------------------------------v
   # | TOC1 | LR1 || ... || _8b_ | _8b_ |
   # +----------------------------------+
-  std   %r2, -16(%r5)  # store in *(ulp_stack + used_size - 16)
-  mflr  %r2
+  std   %r6, -16(%r5)  # store in *(ulp_stack + used_size - 16)
   std   %r2, -8(%r5)   # store in *(ulp_stack + used_size - 8)
 
-  # Restore registers
-  ld    %r5, -8(%r1)  # Restore register.
-  ld    %r6, -16(%r1) # Restore register.
 
-  # Jump to target function
+  # Restore registers
+  ld    %r5, -8(%r1)   # Restore register.
+  ld    %r6, -16(%r1)  # Restore register.
+ #ld    %r2,  -24(%r1) # r2 was already loaded
+  ld    %r3,  -32(%r1)
+  ld    %r12, -40(%r1)
+
+  # jump to target function
   mfctr %r12
   bctrl
 
-  # Load the ulp_stack into r5 through r13 (thread local storage ptr)
-  addis %r5, %r13, ulp_stack@tprel@ha
-  addi  %r5, %r5,  ulp_stack@tprel@l
+  # Save return registers and ones used by __get_tls_addr.
+  std   %r3,  -8(%r1)
+  std   %r12, -16(%r1)
+
+  # Move stack register
+  addi  %r1, %r1, -(16 + 32 + 8) # 32 + 8 for padding
+
+  # Do a trick to load PC into LR register.
+  bl    .return_to_caller
+.return_to_caller:
+  mflr  %r12
+
+  # Get the function address.
+  addi  %r12, %r12, trampoline_routine - .return_to_caller
+
+  # Fix TOC.  %r12 must be pointing to the address of trampoline_routine.
+  addis %r2,%r12, .TOC.-trampoline_routine@ha
+  addi  %r2,%r2 , .TOC.-trampoline_routine@l
+
+  # Load ulp_stack
+  addis %r3, %r2, ulp_stack@got@tlsgd@ha
+  addi  %r3, %r3, ulp_stack@got@tlsgd@l
+
+  # Get address of ulp_stack
+  bl    __tls_get_addr(ulp_stack@tlsgd)
+  nop
 
   # Deference ulp_stack.
-  ld    %r6, ULP_STACK_USED_SIZE(%r5)
+  ld    %r6, ULP_STACK_USED_SIZE(%r3)
   addi  %r6, %r6, -16   # Sub 16 bytes because the first entry stores the top of stack, and we need to store 2 longs.
-  std   %r6, ULP_STACK_USED_SIZE(%r5)     # Store new used_size value.
+  std   %r6, ULP_STACK_USED_SIZE(%r3)     # Store new used_size value.
 
   # Load ulp_stack ptr field.
-  ld    %r5, ULP_STACK_PTR(%r5)
+  ld    %r5, ULP_STACK_PTR(%r3)
 
   # Point to the top of stack but two, these two entries are popped in
   # previous step and accessed in next step (stack size decremented before access).
@@ -119,64 +180,55 @@ trampoline_routine:
   ld    %r8, 8(%r5)     # Restore LR
   mtlr  %r8             # Load LR
 
-  # Return execution to caller.
+  # Restore used registers
+  addi  %r1, %r1, (16 + 32 + 8) # 32 + 8 for padding
+  ld    %r3,  -8(%r1)
+  ld    %r12, -16(%r1)
+
+  # Return.
   blr
 
 .Lexpand_ulp_stack:
 
   # Save all volatile registers
   # r5 & r6 are designated temp regs, having data already on stack.
+  # r0, r2 & r12 is as well in this slow path.
   # After return from expand_ulp_stack, both regs construct values
   # before use.
-  std   %r2,  -24(%r1)
-  std   %r3,  -32(%r1)
-  std   %r4,  -40(%r1)
-  std   %r7,  -48(%r1)
-  std   %r8,  -56(%r1)
-  std   %r9,  -64(%r1)
-  std   %r10, -72(%r1)
-  std   %r11, -80(%r1)
-  std   %r12, -88(%r1)
-  mfctr %r3
-  std   %r3,  -96(%r1)
-  mflr  %r3,
-  std   %r3,  -104(%r1)
+  std   %r4,  -8(%r1)
+  std   %r7,  -16(%r1)
+  std   %r8,  -24(%r1)
+  std   %r9,  -32(%r1)
+  std   %r10, -40(%r1)
+  std   %r11, -48(%r1)
+  mfctr %r4
+  std   %r4,  -56(%r1)
+  mflr  %r4,
+  std   %r4,  -64(%r1)
 
-  # As per ppc64le ABIv2, the minimum stack frame is of 32 bytes and
-  # additional 8 bytes padding is needed for alignment in stack frame.
-  # The regs stored in redzone must have this 32+8 bytes padding to form
-  # auxiliary stack frame before calling ulp_stack_helper which will
-  # have its own proper stack frame.
-
-  # Move stack register
-  addi  %r1, %r1, -(104 + 32 + 8) # 32 + 8 for padding
-
-  # Fix TOC.  %r12 must be pointing to the address of trampoline_routine.
-  addis %r2,%r12, .TOC.-trampoline_routine@ha
-  addi  %r2,%r2 , .TOC.-trampoline_routine@l
+  # Setup stack frame
+  addi  %r1, %r1, -(64 + 32 + 8)
 
   # Call C helper routine.
-  bl ulp_stack_helper
+  bl    ulp_stack_helper
   nop
 
-  # Restore stack register.
-  addi  %r1, %r1, (104 + 32 + 8)
+  # Restore stack frame
+  addi %r1, %r1, (64 + 32 + 8)
 
-  # Restore registers
-  ld    %r3,  -104(%r1)
-  mtlr  %r3
-  ld    %r3,  -96(%r1)
-  mtctr %r3
-  ld    %r12, -88(%r1)
-  ld    %r11, -80(%r1)
-  ld    %r10, -72(%r1)
-  ld    %r9,  -64(%r1)
-  ld    %r8,  -56(%r1)
-  ld    %r7,  -48(%r1)
-  ld    %r4,  -40(%r1)
-  ld    %r3,  -32(%r1)
-  ld    %r2,  -24(%r1)
+  # Load back registers.
+  ld    %r7,  -16(%r1)
+  ld    %r8,  -24(%r1)
+  ld    %r9,  -32(%r1)
+  ld    %r10, -40(%r1)
+  ld    %r11, -48(%r1)
+  ld    %r4,  -56(%r1)
+  mtctr %r4
+  ld    %r4,  -64(%r1)
+  mtlr  %r4
+  ld    %r4,  -8(%r1)
 
+  # Continue execution
   b     .Lcontinue_ulp_prologue
 
 	.long 0
@@ -184,8 +236,12 @@ trampoline_routine:
 	.cfi_endproc
 	.size	trampoline_routine,.-trampoline_routine
 
-	.globl ulp_prologue
-	.type  ulp_prologue, @function
+# The following function needs to be placed in .data, as it is a template to be
+# copied in the prologue of tha patched function.  Placing this in .data avoids
+# text relocations.
+.section        ".data"
+.globl ulp_prologue
+.type  ulp_prologue, @function
 ulp_prologue:
 	.cfi_startproc
   std   %r5, -8(%r1)  # Save one register used as function parameter
@@ -195,7 +251,7 @@ ulp_prologue:
   lis   %r5,  trampoline_routine@highest     #0x1122
   ori   %r5,  %r5, trampoline_routine@higher #0x3344
   lis   %r12, trampoline_routine@high        #0x5566
-  ori   %r12, %r12, trampoline_routine@l      #0x7788
+  ori   %r12, %r12, trampoline_routine@l     #0x7788
 
   # Concatenate two registers
   rldimi %r12, %r5, 32, 0
@@ -223,7 +279,7 @@ ulp_prologue_end = .
 	.size ulp_prologue,.-ulp_prologue
 ulp_prologue_padding_end = .
 
-.section      ".data"
+.section      ".rodata"
 .align        2
 .type         ulp_prologue_size, @object
 .size         ulp_prologue_size, 4

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -695,7 +695,8 @@ TESTS = \
   insn_queue.py \
   chroot.py \
   visibility.py \
-  notes.py
+  notes.py \
+  textrel.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -39,6 +39,7 @@ testname = os.path.basename(testname[0])
 # Libpulp definitions
 builddir = os.getcwd()
 ulptool = builddir + '/../tools/ulp'
+libpulp_path = builddir + '/../lib/.libs/libpulp.so'
 
 # Check if certain library is livepatchable.
 def is_library_livepatchable(library):
@@ -116,7 +117,7 @@ class spawn(pexpect.spawn):
 
     # If env has not been provided, default to LD_PRELOAD'ing libpulp.so.
     if env == Ellipsis:
-      env = {'LD_PRELOAD': builddir + '/../lib/.libs/libpulp.so'}
+      env = {'LD_PRELOAD': libpulp_path}
 
     # Spawn the testcase with pexpect and enable logging.
     super().__init__(testname, timeout=timeout, env=env, encoding=encoding,

--- a/tests/textrel.py
+++ b/tests/textrel.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2025 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import testsuite
+import subprocess
+
+# Make sure libpulp is built without TEXTREL.
+
+command = ['readelf', '-d', testsuite.libpulp_path]
+try:
+  output = subprocess.check_output(command, timeout=10, stderr=subprocess.STDOUT)
+  textrel = re.search('TEXTREL', output.decode())
+  if not textrel:
+    exit(0)
+
+except subprocess.TimeoutExpired:
+  print('readelf timeout')
+  exit(77)
+
+exit(1)


### PR DESCRIPTION
Previous versions of libpulp for the ppc64le generated text relocations, which makes the dynamic linker resolve them when the library is being loaded.  This actually causes a problem when the program is loaded with seccomp mprotect protection, because it needs to set the page to EXECUTABLE and WRITABLE for a short period of time, causing the application to crash.

This commit fixes this by refatoring the code into not using TEXTREL. This comes with a performance cost because __tls_get_addr needs to be called in order for this to work, and more registers needs to be saved for this function to be successfully called.