### PR TITLE
Memory allocation for ulp_stack using brk syscall

### DIFF
--- a/lib/arch/powerpc64le/patch.c
+++ b/lib/arch/powerpc64le/patch.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
 
 #include <stddef.h>
 #include <string.h>
@@ -271,7 +272,7 @@ void *ulp_stack_helper(void)
   void *old = (void *)ulp_stack[ULP_STACK_PTR];
 
   /* Allocate buffer for our stack.  */
-  void *new = mmap(NULL, ulp_stack[ULP_STACK_REAL_SIZE],
+  void *new = (void*) syscall(SYS_mmap, NULL, ulp_stack[ULP_STACK_REAL_SIZE],
                    PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
   if (new == (void *) -1) {


### PR DESCRIPTION
This patch addresses the mmap livepatching issue[1] by allocating ulp_stack through the brk() syscall.

Rather than using the brk() system call interface
provided by glibc, brk is invoked directly via glibc's syscall() function. This change shifts the existing limitation from mmap() to glibc's syscall().
However, glibc's brk() function remains available
for future patching.

Benefits of the New Approach:

1)The simplicity of the syscall() interface reduces
  the vulnerability surface compared to mmap().
  Hence, non-patchable exception for syscall is better.

2)It eliminates the need to copy the content of the
  old ulp_stack after resizing.

[1] https://github.com/SUSE/libpulp/issues/239