### PR TITLE
Add flag for trigger to disable seccomp in target process

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -246,7 +246,8 @@ check_LTLIBRARIES += libdozens_livepatch1.la \
                      libcomments_livepatch1.la \
                      libvisibility_livepatch1.la \
                      libvisibility_livepatch2.la \
-                     libnotes_livepatch1.la
+                     libnotes_livepatch1.la \
+                     libsecdis_livepatch1.la
 
 libdozens_livepatch1_la_SOURCES = libdozens_livepatch1.c
 libdozens_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
@@ -338,6 +339,9 @@ libvisibility_livepatch2_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 libnotes_livepatch1_la_SOURCES = libnotes_livepatch1.c
 libnotes_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
 
+libsecdis_livepatch1_la_SOURCES = libsecdis_livepatch1.c
+libsecdis_livepatch1_la_LDFLAGS = $(CONVENIENCE_LDFLAGS)
+
 METADATA = \
   libdozens_livepatch1.dsc \
   libdozens_livepatch1.ulp \
@@ -398,7 +402,9 @@ METADATA = \
   libvisibility_livepatch2.dsc \
   libvisibility_livepatch2.ulp \
   libnotes_livepatch1.dsc \
-  libnotes_livepatch1.ulp
+  libnotes_livepatch1.ulp \
+  libsecdis_livepatch1.dsc \
+  libsecdis_livepatch1.ulp
 
 EXTRA_DIST = \
   libdozens_livepatch1.in \
@@ -430,7 +436,8 @@ EXTRA_DIST = \
   libstress_livepatch1.in \
   libvisibility_livepatch1.in \
   libvisibility_livepatch2.in \
-  libnotes_livepatch1.in
+  libnotes_livepatch1.in \
+  libsecdis_livepatch1.in
 
 clean-local:
 	rm -f $(METADATA)
@@ -696,7 +703,8 @@ TESTS = \
   chroot.py \
   visibility.py \
   notes.py \
-  textrel.py
+  textrel.py \
+  seccomp_disable.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/libsecdis_livepatch1.c
+++ b/tests/libsecdis_livepatch1.c
@@ -1,0 +1,49 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2020-2021 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <sys/mman.h>
+#include <stdlib.h>
+
+/* This function is here for messing with seccomp.  Seccomp disables
+   mmap with EXEC | WRITE attributes, so if we call it we should get
+   a memory allocation error with ENOPERM.  */
+
+__attribute__((constructor))
+static void initialize(void)
+{
+  void *page = mmap(NULL, 128, PROT_EXEC | PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+  /* Check if we got the page.  */
+  if (page == (void *) -1L || page == NULL) {
+    /* We did not get the page, abort.  */
+    abort();
+  }
+
+  /* Clean memory.  */
+  munmap(page, 128);
+}
+
+int
+baker_dozen(void)
+{
+  return 13;
+}

--- a/tests/libsecdis_livepatch1.in
+++ b/tests/libsecdis_livepatch1.in
@@ -1,0 +1,3 @@
+__ABS_BUILDDIR__/.libs/libsecdis_livepatch1.so
+@__ABS_BUILDDIR__/.libs/libdozens.so.0.json
+dozen:baker_dozen

--- a/tests/seccomp_disable.py
+++ b/tests/seccomp_disable.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2021 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+import sys
+import os
+
+if os.geteuid() == 0:
+    child = testsuite.spawn('block_mprotect ./numserv')
+else:
+    print("Test not running as root.", file=sys.stdout)
+    exit(77) # Skip test
+
+child.expect('Waiting for input.')
+
+child.sendline('dozen')
+child.expect('12');
+
+child.sendline('hundred')
+child.expect('100');
+
+# Now lets try to load a livepatch that would make seccomp complain.
+child.livepatch('.libs/libsecdis_livepatch1.so', disable_seccomp=True)
+
+# See if the process survived.
+child.sendline('dozen')
+child.expect('13', reject='12');
+
+child.close(force=True)
+exit(0)

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -235,7 +235,8 @@ class spawn(pexpect.spawn):
   # output for more information).
   def livepatch(self, filename=None, timeout=10, retries=1,
                 verbose=True, quiet=False, revert=False, revert_lib=None,
-                sanity=True, prefix=None, capture_tool_output=False):
+                sanity=True, prefix=None, capture_tool_output=False,
+                disable_seccomp=False):
 
     # Check sanity of command-line arguments
     if sanity is True:
@@ -263,6 +264,8 @@ class spawn(pexpect.spawn):
     if prefix is not None:
       command.append('-R')
       command.append(str(prefix))
+    if disable_seccomp is True:
+      command.append('--disable-seccomp')
 
     # Apply the live patch and check for common errors
     try:

--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -61,6 +61,7 @@ struct arguments
   int recursive;
   int no_summarization;
   int only_livepatched;
+  int disable_seccomp;
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   int check_stack;
 #endif

--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1666,7 +1666,8 @@ patch_applied(struct ulp_process *process, unsigned char *id, int *result)
  * called after successful thread hijacking.
  */
 int
-apply_patch(struct ulp_process *process, void *metadata, size_t metadata_size)
+apply_patch(struct ulp_process *process, void *metadata, size_t metadata_size,
+            bool disable_seccomp_p)
 {
   int ret;
   struct ulp_thread *thread;
@@ -1686,6 +1687,13 @@ apply_patch(struct ulp_process *process, void *metadata, size_t metadata_size)
   if (set_metadata_buffer(process, metadata, metadata_size)) {
     WARN("unable to write live patch path into target process memory.");
     return ETARGETHOOK;
+  }
+
+  if (disable_seccomp_p) {
+    if (disable_seccomp(process->pid)) {
+      WARN("unable to disable seccomp in target process: %s", libpulp_strerror(errno));
+      return errno;
+    }
   }
 
   thread = process->main_thread;

--- a/tools/introspection.h
+++ b/tools/introspection.h
@@ -173,7 +173,8 @@ int set_path_buffer(struct ulp_process *process, const char *path);
 
 int patch_applied(struct ulp_process *process, unsigned char *id, int *result);
 
-int apply_patch(struct ulp_process *process, void *metadata, size_t size);
+int apply_patch(struct ulp_process *process, void *metadata, size_t size,
+                bool disable_seccomp_p);
 
 int revert_patches_from_lib(struct ulp_process *, const char *);
 

--- a/tools/ptrace.c
+++ b/tools/ptrace.c
@@ -466,6 +466,21 @@ set_regs(int pid, registers_t *regs)
   return 0;
 }
 
+/** @brief Disable seccomp in the target process.
+ *
+ * @return 0 if success, anything else if error.
+ */
+int
+disable_seccomp(int pid)
+{
+  if (ulp_ptrace(PTRACE_SETOPTIONS, pid, NULL, (void *)PTRACE_O_SUSPEND_SECCOMP)) {
+    DEBUG("PTRACE_O_SUSPEND_SECCOMP error: %s.\n", strerror(errno));
+    return errno;
+  }
+
+  return 0;
+}
+
 /** @brief Set timeout timer on run_and_redirect function
  *
  * If for some reason libpulp.so deadlocks when livepatching, the only

--- a/tools/ptrace.h
+++ b/tools/ptrace.h
@@ -62,6 +62,8 @@ int get_regs(int pid, registers_t *regs);
 
 int set_regs(int pid, registers_t *regs);
 
+int disable_seccomp(int pid);
+
 void set_run_and_redirect_timeout(long t);
 
 int run_and_redirect(int pid, registers_t *regs,

--- a/tools/ulp.c
+++ b/tools/ulp.c
@@ -131,6 +131,7 @@ static const char doc[] =
 #define ULP_OP_RECURSIVE 261
 #define ULP_OP_DISABLE_SUMMARIZATION 262
 #define ULP_OP_ONLY_LIVEPATCHED 263
+#define ULP_OP_DISABLE_SECCOMP 264
 
 static struct argp_option options[] = {
   { 0, 0, 0, 0, "Options:", 0 },
@@ -156,6 +157,8 @@ static struct argp_option options[] = {
   { "recursive", ULP_OP_RECURSIVE, 0, 0, "Search for patches recursively", 0 },
   { "root", 'R', "PREFIX", 0,
     "Append prefix to livepatch path when passing it to target process", 0 },
+  { "disable-seccomp", ULP_OP_DISABLE_SECCOMP, 0, 0,
+    "disable seccomp filters on target process (use for testing purposes)", 0 },
 #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
   { "check-stack", 'c', 0, 0, "Check the call stack before live patching", 0 },
 #endif
@@ -369,6 +372,10 @@ parser(int key, char *arg, struct argp_state *state)
 
     case ULP_OP_ONLY_LIVEPATCHED:
       arguments->only_livepatched = 1;
+      break;
+
+    case ULP_OP_DISABLE_SECCOMP:
+      arguments->disable_seccomp = 1;
       break;
 
     case 'u':


### PR DESCRIPTION
Seccomp has been a source of many issues in userspace livepatching. This commit adds a feature for `trigger` to disable seccomp when attempting to livepatch a process, which increases the range of possible livepatches we can do.