### PR TITLE
Fix calling libc.so.6 triggering an assertion error

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -37,7 +37,23 @@ void exit(int);
  **/
 ulp_error_t get_libpulp_error_state(void);
 
+
+/** @brief Set libpulp error state.
+ *
+ * If a fatal error has occured, libpulp cannot continue livepatching processes
+ * because it may be into an unexpected state.  This function sets its state
+ * so livepatching can be marked as disabled for any reason.
+ **/
 void set_libpulp_error_state(ulp_error_t);
+void set_libpulp_error_state_with_reason_func(const char *file, const char *func,
+                                              int line, ulp_error_t state,
+                                              const char *fmt, ...);
+
+/** @brief Macro which passes the current file, function and line number for
+ * logging for the `set_libpulp_error_state_with_reason_func`.
+ */
+#define set_libpulp_error_state_with_reason(...) \
+  set_libpulp_error_state_with_reason_func(__FILE__, __func__, __LINE__, __VA_ARGS__)
 
 /** @brief Check if libpulp is in an fatal error state.
  *

--- a/include/error_common.h
+++ b/include/error_common.h
@@ -68,6 +68,8 @@ typedef int ulp_error_t;
 #define EINSNQ        285 /** Instruction queue in inconsistent state.  */
 #define EOLDULP       286 /** ULP tool is too old.  */
 #define EDLOPEN       287 /** Failure in dlopen.  */
+#define ENOLIBDL      288 /** Libdl not found.  */
+#define ENOLIBC       289 /** Libc not found.  */
 
 /** Table used to map error code to message.  Define it here so that it is
  *  easier for it being maintained.
@@ -106,6 +108,8 @@ typedef int ulp_error_t;
     "Instruction queue in inconsistent state", \
     "ULP tool is too old", \
     "Failure in dlopen", \
+    "Libdl not found." \
+    "Libc not found or unsupported." \
   }
 /* clang-format on */
 

--- a/lib/error.c
+++ b/lib/error.c
@@ -58,6 +58,21 @@ set_libpulp_error_state(ulp_error_t state)
 }
 
 void
+set_libpulp_error_state_with_reason_func(const char *file, const char *func, int line,
+                                         ulp_error_t state, const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+
+  set_libpulp_error_state(state);
+  msgq_push("In file = %s, function = %s, line = %d, error state %d: ", file,
+            func, line, state);
+  msgq_push(fmt, args);
+
+  va_end(args);
+}
+
+void
 libpulp_assert_func(const char *file, const char *func, int line,
                     unsigned long expression)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -704,7 +704,8 @@ TESTS = \
   visibility.py \
   notes.py \
   textrel.py \
-  seccomp_disable.py
+  seccomp_disable.py \
+  run_libc.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/run_libc.py
+++ b/tests/run_libc.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2025 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import testsuite
+import subprocess
+
+# Make sure we can call libc.so.6 and it doesn't crash.
+
+# Distros can have libc in many many places, there seems to be no
+# standard way.  So we try them all.
+libc_potential_paths = (
+  '/usr/lib64/libc.so.6',
+  '/lib64/libc.so.6',
+  '/usr/lib/libc.so.6',
+  '/lib/libc.so.6',
+)
+
+env = {'LD_PRELOAD': testsuite.libpulp_path}
+
+for libc in libc_potential_paths:
+  try:
+    output = subprocess.check_output(libc, timeout=2, stderr=subprocess.STDOUT, env=env)
+    gnu = re.search('GNU C Library', output.decode())
+    if gnu:
+      exit(0)
+  except FileNotFoundError:
+    pass
+
+
+# We tested them all and everything failed.
+exit(1)


### PR DESCRIPTION
Previously, if libpulp is loaded in the entire system, calling

$ /lib64/libc.so.6

results in an 'assertion error' rather than it displaying the glibc version installed in the system.  This commit fixes this using the following approach:

1- If libdl symbols are not found, we disable livepatching in the process.  This is either due to:
  a. libdl is the main process itself, resulting dlopen(RTLD_NEXT)
     to fail.  In this case the library was just called for displaying
     the version number, and it is safe to disable livepatching.

  b. libdl was not loaded in the system.  In this case the application
     can't run dlopen/dlsym, thus we can't livepatch the process.

2- If libdl is not loaded but libc *is* loaded (which can happen on
   older versions of glibc), then pass ahead the calls to the alternate
   __libc_* version of the symbol without requiring libdl.  In such
   cases livepatching is also disabled because we need libdl for
   livepatching.