### PR TITLE
Make sure libpulp.so is built without GLIBC_PRIVATE symbols

### DIFF
--- a/lib/interpose.c
+++ b/lib/interpose.c
@@ -54,7 +54,6 @@ extern void __libc_free(void *);
 extern void *__libc_malloc(size_t);
 extern void *__libc_calloc(size_t, size_t);
 extern void *__libc_realloc(void *, size_t);
-extern void *__libc_reallocarray(void *, size_t, size_t);
 extern void *__libc_valloc(size_t);
 extern void *__libc_pvalloc(size_t);
 extern void *__libc_memalign(size_t, size_t);
@@ -69,7 +68,6 @@ static void (*real_free)(void *) = NULL;
 static void *(*real_malloc)(size_t) = NULL;
 static void *(*real_calloc)(size_t, size_t) = NULL;
 static void *(*real_realloc)(void *, size_t) = NULL;
-static void *(*real_reallocarray)(void *, size_t, size_t) = NULL;
 static void *(*real_valloc)(size_t) = NULL;
 static void *(*real_pvalloc)(size_t) = NULL;
 static void *(*real_memalign)(size_t, size_t) = NULL;
@@ -644,7 +642,6 @@ __ulp_asunsafe_begin(void)
   real_malloc = dlsym(RTLD_NEXT, "malloc");
   real_calloc = dlsym(RTLD_NEXT, "calloc");
   real_realloc = dlsym(RTLD_NEXT, "realloc");
-  real_reallocarray = dlsym(RTLD_NEXT, "reallocarray");
   real_valloc = dlsym(RTLD_NEXT, "valloc");
   real_pvalloc = dlsym(RTLD_NEXT, "pvalloc");
   real_memalign = dlsym(RTLD_NEXT, "memalign");
@@ -669,11 +666,6 @@ __ulp_asunsafe_begin(void)
 
   if (!real_realloc) {
     set_libpulp_error_state_with_reason(ENOLIBC, "unable to find function `realloc`.");
-    ok = false;
-  }
-
-  if (!real_reallocarray) {
-    set_libpulp_error_state_with_reason(ENOLIBC, "unable to find function `reallocarray`.");
     ok = false;
   }
 
@@ -807,22 +799,6 @@ realloc(void *ptr, size_t size)
 
   __sync_fetch_and_add(&flag, 1);
   result = real_realloc(ptr, size);
-  __sync_fetch_and_sub(&flag, 1);
-
-  return result;
-}
-
-void *
-reallocarray(void *ptr, size_t nmemb, size_t size)
-{
-  void *result;
-
-  if (real_reallocarray == NULL) {
-    return __libc_reallocarray(ptr, nmemb, size);
-  }
-
-  __sync_fetch_and_add(&flag, 1);
-  result = real_reallocarray(ptr, nmemb, size);
   __sync_fetch_and_sub(&flag, 1);
 
   return result;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -705,7 +705,8 @@ TESTS = \
   notes.py \
   textrel.py \
   seccomp_disable.py \
-  run_libc.py
+  run_libc.py \
+  glibc_private.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/glibc_private.py
+++ b/tests/glibc_private.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2020-2025 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import testsuite
+import subprocess
+
+# Make sure libpulp is built without links to GLIBC_PRIVATE symbols.
+
+command = ['readelf', '-sW', testsuite.libpulp_path]
+try:
+  output = subprocess.check_output(command, timeout=10, stderr=subprocess.STDOUT)
+  priv = re.search('GLIBC_PRIVATE', output.decode())
+  if not priv:
+    exit(0)
+
+except subprocess.TimeoutExpired:
+  print('readelf timeout')
+  exit(77)
+
+exit(1)


### PR DESCRIPTION
Some symbols from glibc are not meant to be called by external programs, those have `GLIBC_PRIVATE` appended to them, and no other public symbol available to link against.

One of such symbols is `__libc_reallocarray`.  But we don't need to interpose it, as it will eventually call realloc which is a function we interpose.  So eventually the lock will be held correctly.