### PR TITLE
Improve error messaage when container isn't a valid JSON

### DIFF
--- a/tools/extract.c
+++ b/tools/extract.c
@@ -499,7 +499,11 @@ parse_so_json(const char *path)
   int ret;
 
   json_object *root = json_object_from_file(path);
-  assert(root && "Unable to build root object.");
+
+  if (root == NULL) {
+    /* Unable to build root object, most likely not a JSON file.  */
+    return NULL;
+  }
 
   json_object *library = json_object_object_get(root, "library");
   if (!library) {

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -616,6 +616,15 @@ parse_description(const char *filename, struct ulp_metadata *ulp,
   container_path = ulp->so_filename;
   container = ulp_so_info_open(container_path);
 
+  if (container == NULL) {
+    /* Failed to open it.  The file is probably not what we expected it to be,
+       or has missing pieces.  */
+    parse_error(loc,
+          "Unsupported container format. Check if it is a valid ELF or JSON.");
+    ret = 0;
+    goto dsc_clean;
+  }
+
   n = getline(&first, &len, parse_file);
   loc.line++;
   loc.col = 1;
@@ -691,6 +700,16 @@ parse_description(const char *filename, struct ulp_metadata *ulp,
       }
 
       target = ulp_so_info_open(target_path);
+
+      if (target == NULL) {
+        /* Failed to open it.  The file is probably not what we expected it to be,
+           or has missing pieces.  */
+        parse_error(loc,
+             "Unsupported target format. Check if it is a valid ELF or JSON.");
+        ret = 0;
+        goto dsc_clean;
+      }
+
       ulp->objs->name = strdup(target->name);
     }
     else {


### PR DESCRIPTION
Users have attempted to use linker scripts instead of valid ELF files or JSON metadata dumps as input for `packer` tricked by the .so extension in SUSE Linux.  Hence we should display a better error message in such cases.