### PR TITLE
Improve help messages

### DIFF
--- a/tools/arguments.h
+++ b/tools/arguments.h
@@ -26,6 +26,17 @@
 
 #define ARGS_MAX 1
 
+/* switches that don't have a shorthand.  */
+#define ULP_OP_REVERT_ALL 256
+#define ULP_OP_REVERT 257
+#define ULP_OP_COLOR 258
+#define ULP_OP_TIMEOUT 259
+#define ULP_OP_DISABLE_THREADING 260
+#define ULP_OP_RECURSIVE 261
+#define ULP_OP_DISABLE_SUMMARIZATION 262
+#define ULP_OP_ONLY_LIVEPATCHED 263
+#define ULP_OP_DISABLE_SECCOMP 264
+
 typedef enum
 {
   ULP_NONE,

--- a/tools/check.c
+++ b/tools/check.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/user.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "check.h"
@@ -140,4 +141,18 @@ ulp_process_clean:
   free(livepatch);
   release_ulp_process(target);
   return ret;
+}
+
+struct argp_option *
+get_command_option_check(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/check.h
+++ b/tools/check.h
@@ -23,7 +23,10 @@
 #define CHECK_H
 
 struct arguments;
+struct argp_option;
 
 int run_check(struct arguments *);
+
+struct argp_option *get_command_option_check(void);
 
 #endif

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "dump.h"
@@ -120,4 +121,20 @@ run_dump(struct arguments *arguments)
   dump_ulp_comments(arguments->args[0]);
   free(livepatch);
   return 0;
+}
+
+struct argp_option *
+get_command_option_dump(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "buildid", 'b', 0, 0, "Print the build id", 0 },
+    { "revert", ULP_OP_REVERT, 0, 0,
+      "dump reverse patch info.", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/dump.h
+++ b/tools/dump.h
@@ -23,7 +23,10 @@
 #define DUMP_H
 
 struct arguments;
+struct argp_option;
 
 int run_dump(struct arguments *);
+
+struct argp_option *get_command_option_dump(void);
 
 #endif /* DUMP_H */

--- a/tools/extract.c
+++ b/tools/extract.c
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "config.h"
@@ -733,4 +734,20 @@ run_extract(struct arguments *arguments)
   release_so_info(info);
   release_so_info(debuginfo);
   return 0;
+}
+
+struct argp_option *
+get_command_option_extract(void)
+{
+  static struct argp_option options[] = {
+  { 0, 0, 0, 0, "Options:", 0 },
+  { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+  { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+  { "output", 'o', "FILE", 0, "Write output to FILE", 0 },
+  { "with-debuginfo", 'd', "DEBUGINFO", 0,
+    "Use debuginfo information for symbolextraction", 0 },
+  { 0 }
+  };
+
+  return options;
 }

--- a/tools/extract.h
+++ b/tools/extract.h
@@ -9,6 +9,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+struct argp_option;
+
 /** Struct containing useful information for Userspace Livepatching retrieved
  *  from the target .so file.
  */
@@ -69,5 +71,7 @@ struct symbol *get_symbol_with_name(struct ulp_so_info *info, const char *sym);
 int run_extract(struct arguments *arguments);
 
 struct ulp_so_info *ulp_so_info_open(const char *path);
+
+struct argp_option *get_command_option_extract(void);
 
 #endif /* _EXTRACT_H_.  */

--- a/tools/livepatchable.c
+++ b/tools/livepatchable.c
@@ -25,6 +25,7 @@
 #include <libelf.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "config.h"
@@ -69,4 +70,16 @@ run_livepatchable(struct arguments *arguments)
   close(fd);
 
   return ret;
+}
+
+struct argp_option *
+get_command_option_livepatchable(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { 0 }
+  };
+  return options;
 }

--- a/tools/livepatchable.h
+++ b/tools/livepatchable.h
@@ -23,7 +23,11 @@
 #define LIVEPATCHABLE_H
 
 struct arguments;
+struct argp_option;
 
 int run_livepatchable(struct arguments *);
+
+struct argp_option *
+get_command_option_livepatchable(void);
 
 #endif /* LIVEPATCHABLE.H */

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <sys/user.h>
 #include <unistd.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "config.h"
@@ -168,4 +169,17 @@ run_messages(struct arguments *arguments)
 ulp_process_clean:
   release_ulp_process(target);
   return ret;
+}
+
+struct argp_option *
+get_command_option_messages(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+    { 0 }
+  };
+  return options;
 }

--- a/tools/messages.h
+++ b/tools/messages.h
@@ -23,7 +23,10 @@
 #define MESSAGES_H
 
 struct arguments;
+struct argp_option;
 
 int run_messages(struct arguments *);
+
+struct argp_option *get_command_option_messages(void);
 
 #endif /* MESSAGES.H */

--- a/tools/packer.c
+++ b/tools/packer.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "config.h"
@@ -1252,4 +1253,23 @@ main_error:
     WARN("metadata file generation failed.");
   }
   return ret;
+}
+
+struct argp_option *
+get_command_option_packer(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { 0, 0, 0, 0, "packer commands only:", 0 },
+    { "output", 'o', "FILE", 0, "Write output to FILE", 0 },
+    { "livepatch", 'l', "LIVEPATCH", 0,
+      "Use this livepatch file\nDefaults to the one described in ARG1", 0 },
+    { "target", 't', "LIBRARY", 0,
+      "Use this target library\nDefaults to the one described in ARG1", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/packer.h
+++ b/tools/packer.h
@@ -30,6 +30,7 @@
 
 struct arguments;
 struct ulp_so_info;
+struct argp_option;
 
 void unload_elf(Elf **elf, int *fd);
 
@@ -57,5 +58,7 @@ int get_elf_buildid(Elf *elf, char *buf, unsigned *len);
 void *get_symbol_addr(Elf *elf, Elf_Scn *s, const char *search);
 
 int run_packer(struct arguments *);
+
+struct argp_option *get_command_option_packer(void);
 
 #endif /* PACKER_H */

--- a/tools/patches.c
+++ b/tools/patches.c
@@ -666,3 +666,24 @@ run_patches(struct arguments *arguments)
 
   return any_error == 0 ? 0 : 1;
 }
+
+struct argp_option *
+get_command_option_patches(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+    { "user", 'u', "user", 0, "User name, wildcard, or UID", 0 },
+    { "disable-threading", ULP_OP_DISABLE_THREADING, 0, 0,
+      "Do not launch additional threads", 0 },
+    { "buildid", 'b', 0, 0, "Print the build id", 0 },
+    { "only-livepatched", ULP_OP_ONLY_LIVEPATCHED, 0, 0, "Print only processes that were livepatched", 0 },
+    { "color", ULP_OP_COLOR, "yes/no/auto", 0, "Enable/disable colored messages", 0 },
+    { 0, 0, 0, 0, "extract command only:", 0 },
+    { 0 }
+  };
+
+  return options;
+}

--- a/tools/patches.h
+++ b/tools/patches.h
@@ -29,6 +29,7 @@
 
 struct arguments;
 struct ulp_process;
+struct argp_option;
 
 struct ulp_process_iterator
 {
@@ -67,5 +68,7 @@ const char *buildid_to_string(const unsigned char[BUILDID_LEN]);
 size_t extract_ulp_comment_to_mem(const char *livepatch, char **out);
 
 int run_patches(struct arguments *);
+
+struct argp_option *get_command_option_patches(void);
 
 #endif

--- a/tools/post.c
+++ b/tools/post.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <argp.h>
 
 #include <libelf.h>
 
@@ -147,4 +148,17 @@ run_post(struct arguments *arguments)
   close(fd);
 
   return 0;
+}
+
+struct argp_option *
+get_command_option_post(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/post.h
+++ b/tools/post.h
@@ -30,4 +30,6 @@ struct Elf_Scn *find_section_by_name(struct Elf *, const char *name);
 
 int run_post(struct arguments *);
 
+struct argp_option *get_command_option_post(void);
+
 #endif /* POST_H */

--- a/tools/set_patchable.c
+++ b/tools/set_patchable.c
@@ -27,6 +27,7 @@
 
 #include <stddef.h>
 #include <unistd.h>
+#include <argp.h>
 
 /** Enable or disable threading in process discovery.  */
 extern bool enable_threading;
@@ -116,6 +117,7 @@ run_set_patchable(struct arguments *arguments)
   ulp_verbose = arguments->verbose;
   enable_threading = !arguments->disable_threads;
   const char *process_wildcard = arguments->process_wildcard;
+  const char *user_wildcard = arguments->user_wildcard;
   int retries = arguments->retries;
   bool enable;
   struct ulp_process *p;
@@ -131,10 +133,28 @@ run_set_patchable(struct arguments *arguments)
     return 1;
   }
 
-  FOR_EACH_ULP_PROCESS_MATCHING_WILDCARD(p, process_wildcard)
+  FOR_EACH_ULP_PROCESS_FROM_USER_WILDCARD(p, process_wildcard, user_wildcard)
   {
     enable_or_disable_patching(p, enable, retries);
   }
 
   return 0;
+}
+
+struct argp_option *
+get_command_option_set_patchable(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+    { "user", 'u', "user", 0, "User name, wildcard, or UID", 0 },
+    { "disable-threading", ULP_OP_DISABLE_THREADING, 0, 0,
+    "Do not launch additional threads", 0 },
+    { "retries", 'r', "N", 0, "Retry N times if process busy", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/set_patchable.h
+++ b/tools/set_patchable.h
@@ -23,7 +23,10 @@
 #define SET_PATCHABLE_H
 
 struct arguments;
+struct argp_option;
 
 int run_set_patchable(struct arguments *);
+
+struct argp_option *get_command_option_set_patchable(void);
 
 #endif

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <sys/user.h>
 #include <unistd.h>
+#include <argp.h>
 
 #include "arguments.h"
 #include "config.h"
@@ -616,7 +617,7 @@ static bool check_sys_admin(void)
       goto sys_adm_clear;
     }
   }
-  
+
 sys_adm_clear:
   FREE_AND_NULLIFY(line);
   fclose(file);
@@ -665,4 +666,41 @@ run_trigger(struct arguments *arguments)
                                library, check_stack, revert);
 
   return ret;
+}
+
+struct argp_option *
+get_command_option_trigger(void)
+{
+  static struct argp_option options[] = {
+    { 0, 0, 0, 0, "Options:", 0 },
+    { "verbose", 'v', 0, 0, "Produce verbose output", 0 },
+    { "quiet", 'q', 0, 0, "Don't produce any output", 0 },
+    { "process", 'p', "process", 0, "Target process name, wildcard, or PID", 0 },
+    { "user", 'u', "user", 0, "User name, wildcard, or UID", 0 },
+    { "disable-threading", ULP_OP_DISABLE_THREADING, 0, 0,
+      "Do not launch additional threads", 0 },
+    { "revert-all", ULP_OP_REVERT_ALL, "LIB", 0,
+      "Revert all patches from LIB. If LIB=target, then all patches from the "
+      "target library within the passed livepatch will be reverted.",
+      0 },
+    { "timeout", ULP_OP_TIMEOUT, "t", 0,
+      "Set trigger timeout to t seconds (default 200s)", 0 },
+    { "disable-summarization", ULP_OP_DISABLE_SUMMARIZATION, 0, 0,
+      "Disable trigger ouput summarization", 0 },
+    { "recursive", ULP_OP_RECURSIVE, 0, 0, "Search for patches recursively", 0 },
+    { "root", 'R', "PREFIX", 0,
+      "Append prefix to livepatch path when passing it to target process", 0 },
+    { "disable-seccomp", ULP_OP_DISABLE_SECCOMP, 0, 0,
+      "disable seccomp filters on target process (use for testing purposes)", 0 },
+  #if defined ENABLE_STACK_CHECK && ENABLE_STACK_CHECK
+    { "check-stack", 'c', 0, 0, "Check the call stack before live patching", 0 },
+  #endif
+    { "retries", 'r', "N", 0, "Retry N times if process busy", 0 },
+    { "revert", ULP_OP_REVERT, 0, 0,
+      "revert livepatch.", 0 },
+    { "color", ULP_OP_COLOR, "yes/no/auto", 0, "Enable/disable colored messages", 0 },
+    { 0 }
+  };
+
+  return options;
 }

--- a/tools/trigger.h
+++ b/tools/trigger.h
@@ -23,7 +23,11 @@
 #define TRIGGER_H
 
 struct arguments;
+struct argp_option;
 
 int run_trigger(struct arguments *);
+
+struct argp_option *
+get_command_option_trigger(void);
 
 #endif /* TRIGGER_H */


### PR DESCRIPTION
Previously, the `ulp --help` command's output was not helpful at showing possible options for each command, once everything was displayed.  Now, a much more sensible approach is to:
```
  $ ulp COMMAND --help
```
which now show what options is supported to what command.