### PR TITLE
Do not attempt to hijack terminated processes

### DIFF
--- a/tools/introspection.c
+++ b/tools/introspection.c
@@ -1494,6 +1494,12 @@ hijack_threads(struct ulp_process *process)
   snprintf(taskname, PATH_MAX, "/proc/%d/task", pid);
   taskdir = opendir(taskname);
   if (taskdir == NULL) {
+    /* In the case the error is ENOENT, that means the process ended between
+       the process discovery and here, the process hijacking.  */
+    if (errno == ENOENT) {
+      return ESRCH;
+    }
+
     WARN("error opening %s: %s.", taskname, strerror(errno));
     return errno;
   }

--- a/tools/trigger.c
+++ b/tools/trigger.c
@@ -54,7 +54,8 @@ static bool
 skippable_error(ulp_error_t err)
 {
   return err == EBUILDID || err == ENOTARGETLIB || err == EUSRBLOCKED ||
-         err == EWILDNOMATCH || err == EAPPLIED || err == ENOPATCH;
+         err == EWILDNOMATCH || err == EAPPLIED || err == ENOPATCH ||
+         err == ESRCH;
 }
 
 enum


### PR DESCRIPTION
The `ulp trigger` command uses two threads, one to discover which processes are suitable to patching, and another to actually patch the process.  This is done for performance issues, as discovery is much faster than patching and can be done in parallel.

But what happens if the process is terminated right after the process discovery, but before patching?  Trigger will try to hijack the threads but it will fail with a ENOENT.  This is not a valid failure and should be marked as "SKIPPED".  This commit fixes this by capturing this ENOENT error and mark as such.

Fixes #254. 