### PR TITLE
Fix dlopen directory lookup behavior

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -478,7 +478,8 @@ check_PROGRAMS = \
   insn_queue \
   chroot \
   visibility \
-  notes
+  notes \
+  dlopen
 
 numserv_SOURCES = numserv.c
 numserv_LDADD = libdozens.la libhundreds.la
@@ -648,6 +649,11 @@ notes_DEPENDENCIES = notes.ld $(POST_PROCESS) $(METADATA)
 
 EXTRA_DIST += notes.ld
 
+dlopen_SOURCES = dlopen.c
+dlopen_CFLAGS = $(AM_CFLAGS)
+dlsym_LDADD = -lpthread -ldl -lrt
+dlsym_DEPENDENCIES = libhundreds.la
+
 TESTS = \
   numserv.py \
   numserv_bsymbolic.py \
@@ -707,7 +713,8 @@ TESTS = \
   textrel.py \
   seccomp_disable.py \
   run_libc.py \
-  glibc_private.py
+  glibc_private.py \
+  dlopen.py
 
 XFAIL_TESTS = \
   blocked.py \

--- a/tests/dlopen.c
+++ b/tests/dlopen.c
@@ -1,0 +1,40 @@
+/*
+ *  libpulp - User-space Livepatching Library
+ *
+ *  Copyright (C) 2025 SUSE Software Solutions GmbH
+ *
+ *  This file is part of libpulp.
+ *
+ *  libpulp is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  libpulp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+int main()
+{
+  void *handle = dlopen(".libs/libhundreds.so", RTLD_NOW | RTLD_GLOBAL);
+  if (!handle) {
+    printf("Failed to load libhundreds.so: %s\n", dlerror());
+    return 1;
+  }
+  int (*hundred)(void) = dlsym(handle, "hundred");
+  do {
+    printf("hundred: %d\n", hundred());
+    sleep(1);
+  } while (1);
+
+  return 0;
+}

--- a/tests/dlopen.py
+++ b/tests/dlopen.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#   libpulp - User-space Livepatching Library
+#
+#   Copyright (C) 2025 SUSE Software Solutions GmbH
+#
+#   This file is part of libpulp.
+#
+#   libpulp is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public
+#   License as published by the Free Software Foundation; either
+#   version 2.1 of the License, or (at your option) any later version.
+#
+#   libpulp is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with libpulp.  If not, see <http://www.gnu.org/licenses/>.
+
+import testsuite
+
+child = testsuite.spawn(testsuite.testname)
+
+child.expect('100', reject='Failed to load libhundreds.so')
+
+child.close(force=True)
+exit(0)


### PR DESCRIPTION
Since `dlopen` and `dlmopen` were interposed, it changed the search paths because the caller were now `libpulp.so.0` rather than the original application.  This interposition were done for reasons of ensuring that we knew when an application has called `dlopen` by locking a lock in libpulp, but its not necessary anymore since we hijack the `dl_load_lock` from glibc.