### PR TITLE
Use configured Python interpreter for generating dsc files

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -63,7 +63,7 @@ CONVENIENCE_LDFLAGS = -rpath $(libdir) $(AM_LDFLAGS)
 # does not create .so targets).
 %.dsc: %.in $(check_LTLIBRARIES)
 	sed -e "s|__ABS_BUILDDIR__|$(abs_builddir)|" $< > $*.tmp
-	$(top_srcdir)/tests/offsets.py $*.tmp $@
+	$(PYTHON) -B $(top_srcdir)/tests/offsets.py $*.tmp $@
 	rm -f $*.tmp
 
 # This rule build the .ulp file, which at some point were used to hold


### PR DESCRIPTION
In Makefile.common, the %.dsc rule directly executes the offsets.py script, which relies on the system shebang. In environments where the python interpreter is explicitly configured (such as during packaging, cross-compilation, or in non-standard setups), this can bypass the selected Python interpreter.